### PR TITLE
Develop

### DIFF
--- a/include/BingoCpp/utils.h
+++ b/include/BingoCpp/utils.h
@@ -13,6 +13,8 @@
 
 #include <iostream>
 #include <stdlib.h>
+#include <vector>
+#include <cmath>
 #include <Eigen/Dense>
 #include <Eigen/Core>
 

--- a/src/acyclic_graph.cpp
+++ b/src/acyclic_graph.cpp
@@ -168,13 +168,14 @@ std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvaluateWithDerivativeAndMask(
   const Eigen::VectorXd &constants,
   const std::vector<bool> &mask,
   const bool param_x_or_c) {
+  std::cout<<"1"<<std::endl;
   // Evaluates a stack and its derivative with the given x and constants.
   std::vector<Eigen::ArrayXXd> forward_eval(stack.rows());
   std::vector<std::set<int>> stack_dependencies(stack.rows(),
                           std::set<int>());
   int deriv_size;
   int deriv_operator_number;
-
+  std::cout<<"2"<<std::endl;
   if (param_x_or_c) {  // true = x
     deriv_size = x.cols();
     deriv_operator_number = 0;
@@ -183,9 +184,9 @@ std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvaluateWithDerivativeAndMask(
     deriv_size = constants.size();
     deriv_operator_number = 1;
   }
-
+  std::cout<<"3"<<std::endl;
   std::vector<std::set<int>> param_dependencies(deriv_size, std::set<int>());
-
+  std::cout<<"4"<<std::endl;
   // forward eval with dependencies
   for (std::size_t i = 0; i < stack.rows(); ++i) {
     if (mask[i]) {
@@ -202,11 +203,11 @@ std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvaluateWithDerivativeAndMask(
       }
     }
   }
-
+  std::cout<<"5"<<std::endl;
   // reverse pass through stack
   std::vector<Eigen::ArrayXXd> reverse_eval(stack.rows());
   reverse_eval[stack.rows() - 1] = Eigen::ArrayXXd::Ones(x.rows(), 1);
-
+  std::cout<<"6"<<std::endl;
   for (int i = stack.rows() - 2; i >= 0; --i) {
     if (mask[i]) {
       reverse_eval[i] = Eigen::ArrayXXd::Zero(x.rows(), 1);
@@ -214,16 +215,16 @@ std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvaluateWithDerivativeAndMask(
                            stack_dependencies[i]);
     }
   }
-
+  std::cout<<"7"<<std::endl;
   // build derivative array
   Eigen::ArrayXXd deriv = Eigen::ArrayXXd::Zero(x.rows(), deriv_size);
-
+  std::cout<<"8"<<std::endl;
   for (std::size_t i = 0; i < deriv_size; ++i) {
     for (auto const& dependency : param_dependencies[i]) {
       deriv.col(i) += reverse_eval[dependency];
     }
   }
-
+  std::cout<<"9"<<std::endl;
   return std::make_pair(forward_eval.back(), deriv);
 }
 

--- a/src/acyclic_graph.cpp
+++ b/src/acyclic_graph.cpp
@@ -189,16 +189,20 @@ std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvaluateWithDerivativeAndMask(
   std::cout<<"4"<<std::endl;
   // forward eval with dependencies
   for (std::size_t i = 0; i < stack.rows(); ++i) {
+    std::cout<<"  4.0 :"<<i<<std::endl;
     if (mask[i]) {
+      std::cout<<"  4.1"<<std::endl;
       oper_interface.operator_map[stack(i, 0)]->evaluate(
         stack, x, constants, forward_eval, i);
-
+      std::cout<<"  4.2"<<std::endl;
       if (stack(i, 0) == deriv_operator_number) {
+        std::cout<<"  4.3"<<std::endl;
         param_dependencies[stack(i, 1)].insert(i);
       }
-
+      std::cout<<"  4.4"<<std::endl;
       for (int j = 0; j < oper_interface.operator_map[stack(i, 0)]->get_arity();
            ++j) {
+        std::cout<<"  4.5 :(,"<<i<<","<<j<<")"<<std::endl;
         stack_dependencies[stack(i, j + 1)].insert(i);
       }
     }

--- a/src/acyclic_graph.cpp
+++ b/src/acyclic_graph.cpp
@@ -168,14 +168,14 @@ std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvaluateWithDerivativeAndMask(
   const Eigen::VectorXd &constants,
   const std::vector<bool> &mask,
   const bool param_x_or_c) {
-  std::cout<<"1"<<std::endl;
+  
   // Evaluates a stack and its derivative with the given x and constants.
   std::vector<Eigen::ArrayXXd> forward_eval(stack.rows());
   std::vector<std::set<int>> stack_dependencies(stack.rows(),
                           std::set<int>());
   int deriv_size;
   int deriv_operator_number;
-  std::cout<<"2"<<std::endl;
+
   if (param_x_or_c) {  // true = x
     deriv_size = x.cols();
     deriv_operator_number = 0;
@@ -184,36 +184,26 @@ std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvaluateWithDerivativeAndMask(
     deriv_size = constants.size();
     deriv_operator_number = 1;
   }
-  std::cout<<"3"<<std::endl;
+
   std::vector<std::set<int>> param_dependencies(deriv_size, std::set<int>());
-  std::cout<<"4"<<std::endl;
+
   // forward eval with dependencies
-  std::cout<<"stack inside of eval EvaluateWithDerivativeAndMask"<<std::endl;
-  std::cout<<stack<<std::endl;
   for (std::size_t i = 0; i < stack.rows(); ++i) {
-    std::cout<<"  4.0 :"<<i<<std::endl;
     if (mask[i]) {
-      std::cout<<"  4.1"<<std::endl;
       oper_interface.operator_map[stack(i, 0)]->evaluate(
         stack, x, constants, forward_eval, i);
-      std::cout<<"  4.2"<<std::endl;
       if (stack(i, 0) == deriv_operator_number) {
-        std::cout<<"  4.3"<<std::endl;
         param_dependencies[stack(i, 1)].insert(i);
       }
-      std::cout<<"  4.4"<<std::endl;
       for (int j = 0; j < oper_interface.operator_map[stack(i, 0)]->get_arity();
            ++j) {
-        std::cout<<"  4.5 :(,"<<i<<","<<j<<")"<<std::endl;
         stack_dependencies[stack(i, j + 1)].insert(i);
       }
     }
   }
-  std::cout<<"5"<<std::endl;
   // reverse pass through stack
   std::vector<Eigen::ArrayXXd> reverse_eval(stack.rows());
   reverse_eval[stack.rows() - 1] = Eigen::ArrayXXd::Ones(x.rows(), 1);
-  std::cout<<"6"<<std::endl;
   for (int i = stack.rows() - 2; i >= 0; --i) {
     if (mask[i]) {
       reverse_eval[i] = Eigen::ArrayXXd::Zero(x.rows(), 1);
@@ -221,16 +211,13 @@ std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvaluateWithDerivativeAndMask(
                            stack_dependencies[i]);
     }
   }
-  std::cout<<"7"<<std::endl;
   // build derivative array
   Eigen::ArrayXXd deriv = Eigen::ArrayXXd::Zero(x.rows(), deriv_size);
-  std::cout<<"8"<<std::endl;
   for (std::size_t i = 0; i < deriv_size; ++i) {
     for (auto const& dependency : param_dependencies[i]) {
       deriv.col(i) += reverse_eval[dependency];
     }
   }
-  std::cout<<"9"<<std::endl;
   return std::make_pair(forward_eval.back(), deriv);
 }
 

--- a/src/acyclic_graph.cpp
+++ b/src/acyclic_graph.cpp
@@ -188,6 +188,8 @@ std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvaluateWithDerivativeAndMask(
   std::vector<std::set<int>> param_dependencies(deriv_size, std::set<int>());
   std::cout<<"4"<<std::endl;
   // forward eval with dependencies
+  std::cout<<"stack inside of eval EvaluateWithDerivativeAndMask"<<std::endl;
+  std::cout<<stack<<std::endl;
   for (std::size_t i = 0; i < stack.rows(); ++i) {
     std::cout<<"  4.0 :"<<i<<std::endl;
     if (mask[i]) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "BingoCpp/utils.h"
+#include <vector>
 #include <numeric>
 
 
@@ -17,7 +18,7 @@ std::vector<Eigen::ArrayXXd> calculate_partials(Eigen::ArrayXXd x) {
   break_points.push_back(0);
 
   for (int i = 0; i < x.rows(); ++i) {
-    if (isnan(x(i))) {
+    if (std::isnan(x(i))) {
       break_points.push_back(i);
     }
   }

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -1,0 +1,114 @@
+#include <stdio.h>
+#include <math.h>
+
+#include <iostream>
+#include <vector>
+#include <Eigen/Dense>
+
+#include "gtest/gtest.h"
+#include "BingoCpp/acyclic_graph.h"
+#include "BingoCpp/graph_manip.h"
+
+namespace {
+
+struct AGraphValues {
+	Eigen::ArrayXXd x_vals;
+	std::vector<double> constants;
+};
+
+class AGraphBackend : public ::testing::TestWithParam<int> {
+ public:
+ 	const double TESTING_TOL = 1e-7;
+	const double AGRAPH_VAL_START =-1;
+	const double AGRAPH_VAL_END = 0;
+	const int N_AGRAPH_VAL = 11;
+	const int N_OPS = 13;
+
+	AGraphValues *sample_agraph_1_values;
+	std::vector<Eigen::ArrayXXd> *operator_evals_x0;
+	std::vector<Eigen::ArrayXXd> operator_x_derivs;
+	std::vector<Eigen::ArrayXXd> operator_c_derivs;
+	Eigen::ArrayXXd sample_stack;
+	Eigen::ArrayXXd all_funcs_stack;
+	AcyclicGraph indv;
+  virtual void SetUp() {
+  	sample_agraph_1_values = init_agraph_vals(AGRAPH_VAL_START,
+  																						 AGRAPH_VAL_END,
+  																						 N_AGRAPH_VAL);
+  	operator_evals_x0 = init_op_evals_x0(sample_agraph_1_values);
+
+		return;
+  }
+  virtual void TearDown() {
+  	delete operator_evals_x0	;
+  	delete sample_agraph_1_values;
+  	return; 
+  }
+ private:
+ 	AGraphValues *init_agraph_vals(double begin, double end, int num_points) {
+ 		std::vector<double> constants = {10, 3.14};
+
+ 		Eigen::ArrayXXd x_vals(num_points, 1);
+ 		x_vals = Eigen::ArrayXd::LinSpaced(num_points, begin, end);
+ 		AGraphValues *sample_vals = new AGraphValues();
+ 		sample_vals->x_vals = x_vals;
+ 		sample_vals->constants = constants;
+ 		return sample_vals;
+ 	}
+
+ 	std::vector<Eigen::ArrayXXd> *init_op_evals_x0(AGraphValues *sample_agraph_1_values) {
+
+ 		Eigen::ArrayXXd x_0 = sample_agraph_1_values->x_vals;
+ 		Eigen::ArrayXXd c_0(x_0.rows(), 1);
+
+ 		//TODO use eigen interface to fill constant array
+ 		double constant = sample_agraph_1_values->constants.at(0);
+ 		for (int i=0; i<x_0.rows(); i++) {
+ 			c_0 << constant;
+ 		}
+ 		std::vector<Eigen::ArrayXXd> *op_evals_x0 = new std::vector<Eigen::ArrayXXd>(N_OPS);
+ 		op_evals_x0->push_back(x_0);
+ 		op_evals_x0->push_back(c_0);
+ 		op_evals_x0->push_back(x_0+x_0);
+ 		op_evals_x0->push_back(x_0-x_0);
+ 		op_evals_x0->push_back(x_0*x_0);
+ 		op_evals_x0->push_back(x_0/x_0);
+ 		op_evals_x0->push_back(x_0.sin());
+ 		op_evals_x0->push_back(x_0.cos());
+ 		op_evals_x0->push_back(x_0.exp());
+ 		op_evals_x0->push_back(x_0.abs().log());
+ 		op_evals_x0->push_back(x_0.pow(x_0.abs()));
+ 		op_evals_x0->push_back(x_0.abs());
+ 		op_evals_x0->push_back(x_0.abs().sqrt());
+
+ 		return op_evals_x0;
+ 	}
+};
+
+TEST_P(AGraphBackend, simplify_and_evaluate) {
+	Eigen::ArrayX3i stack(3, 3);
+	const int operator_i = GetParam();
+	stack << 0, 0, 0,
+					 0, 1, 0,
+					 operator_i, 0, 0;
+	// f_of_x = indv.simplify_and_evaluate(stack,
+	// 																		sample_agraph_1_values.x_vals,
+	// 																		sample_agraph_1_values.constants);
+	ASSERT_TRUE(GetParam());
+	// ASSERT_(ASSERT_NEAR(expected_outcome, f_of_x, TOL));
+}
+
+TEST_P(AGraphBackend, simplify_and_evaluate_x_deriv) {
+	const int operator_i = GetParam();
+	ASSERT_TRUE(GetParam());
+}
+
+TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {
+	const int operator_i = GetParam();
+	ASSERT_TRUE(GetParam());
+}
+
+
+INSTANTIATE_TEST_CASE_P(Instance, AGraphBackend, ::testing::Values(1, 2, 3));
+
+} // namespace

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -9,7 +9,6 @@
 #include "BingoCpp/acyclic_graph.h"
 #include "BingoCpp/graph_manip.h"
 
-// TODO refactor code to work with ArrayXd instead of ArrayXXd
 namespace {
 
 struct AGraphValues {
@@ -19,7 +18,7 @@ struct AGraphValues {
 
 class AGraphBackend : public ::testing::TestWithParam<int> {
  public:
- 	const double TESTING_TOL = 1e-7;
+	const double TESTING_TOL = 1e-7;
 	const double AGRAPH_VAL_START =-1;
 	const double AGRAPH_VAL_END = 0;
 	const int N_AGRAPH_VAL = 11;
@@ -30,156 +29,153 @@ class AGraphBackend : public ::testing::TestWithParam<int> {
 	std::vector<Eigen::ArrayXXd> operator_x_derivs;
 	std::vector<Eigen::ArrayXXd> operator_c_derivs;
 
-  virtual void SetUp() {
-  	sample_agraph_1_values = init_agraph_vals(AGRAPH_VAL_START,
-																						  AGRAPH_VAL_END,
-											 												N_AGRAPH_VAL);
-  	operator_evals_x0 = init_op_evals_x0(sample_agraph_1_values);
-  	operator_x_derivs = init_op_x_derivs(sample_agraph_1_values);
-  	operator_c_derivs = init_op_c_derivs(sample_agraph_1_values);
-  }
+	virtual void SetUp() {
+		sample_agraph_1_values = init_agraph_vals(AGRAPH_VAL_START,
+																							AGRAPH_VAL_END,
+																							N_AGRAPH_VAL);
+		operator_evals_x0 = init_op_evals_x0(sample_agraph_1_values);
+		operator_x_derivs = init_op_x_derivs(sample_agraph_1_values);
+		operator_c_derivs = init_op_c_derivs(sample_agraph_1_values);
+	}
 
-  virtual void TearDown() {}
+	virtual void TearDown() {}
 
 
-  double difference(double val_1, double val_2) {
-  	if ((std::isnan(val_1) && std::isnan(val_2)) ||
-  			(val_1 == INFINITY && val_2 == INFINITY) ||
-  			(val_1 == -INFINITY && val_2 == -INFINITY)) {
+	double difference(double val_1, double val_2) {
+		if ((std::isnan(val_1) && std::isnan(val_2)) ||
+				(val_1 == INFINITY && val_2 == INFINITY) ||
+				(val_1 == -INFINITY && val_2 == -INFINITY)) {
 			return 0;
 		} else {
 			return val_1 - val_2;
 		}
-  }
+	}
 
-  bool almostEqual(const Eigen::ArrayXXd &array1, 
-  								 const Eigen::ArrayXXd &array2) {
-  	
-  	Eigen::MatrixXd mat1 = Eigen::MatrixXd(array1);
-  	Eigen::MatrixXd mat2 = Eigen::MatrixXd(array2);
-  	int rows_mat1 = mat1.rows();
-  	int rows_mat2 = mat2.rows();
-  	int cols_mat1 = mat1.cols();
-  	int cols_mat2 = mat2.cols();
+	bool almostEqual(const Eigen::ArrayXXd &array1, 
+									 const Eigen::ArrayXXd &array2) {
+		
+		Eigen::MatrixXd mat1 = Eigen::MatrixXd(array1);
+		Eigen::MatrixXd mat2 = Eigen::MatrixXd(array2);
+		int rows_mat1 = mat1.rows();
+		int rows_mat2 = mat2.rows();
+		int cols_mat1 = mat1.cols();
+		int cols_mat2 = mat2.cols();
 
-  	
-  	if (!(rows_mat1>0) || !(rows_mat2>0) || !(cols_mat1 > 0) || !(cols_mat2 > 0)
-  		|| (rows_mat1 != rows_mat2) || (cols_mat1 != cols_mat2))
-  		return false;
+		
+		if (!(rows_mat1>0) || !(rows_mat2>0) || !(cols_mat1 > 0) || !(cols_mat2 > 0)
+			|| (rows_mat1 != rows_mat2) || (cols_mat1 != cols_mat2))
+			return false;
 
-  	Eigen::MatrixXd matrix_diff = Eigen::MatrixXd(rows_mat1, cols_mat1);
-  	for (int row = 0; row < rows_mat1; row++) {
-  		for (int col = 0; col < cols_mat1; col++) {
-  			matrix_diff(row, col) = difference(mat1(row, col), mat2(row, col));
-  		}
+		Eigen::MatrixXd matrix_diff = Eigen::MatrixXd(rows_mat1, cols_mat1);
+		for (int row = 0; row < rows_mat1; row++) {
+			for (int col = 0; col < cols_mat1; col++) {
+				matrix_diff(row, col) = difference(mat1(row, col), mat2(row, col));
+			}
 		}
 
 		double frobenius_norm = matrix_diff.norm();
-  	return (frobenius_norm < TESTING_TOL ? true : false);
-  }
+		return (frobenius_norm < TESTING_TOL ? true : false);
+	}
 
  private:
- 	AGraphValues init_agraph_vals(double begin, double end, int num_points) {
- 		Eigen::VectorXd constants = Eigen::VectorXd(2);
- 		constants << 10, 3.14;
+	AGraphValues init_agraph_vals(double begin, double end, int num_points) {
+		Eigen::VectorXd constants = Eigen::VectorXd(2);
+		constants << 10, 3.14;
 
- 		Eigen::ArrayXXd x_vals(num_points, 1);
- 		x_vals = Eigen::ArrayXd::LinSpaced(num_points, begin, end);
+		Eigen::ArrayXXd x_vals(num_points, 1);
+		x_vals = Eigen::ArrayXd::LinSpaced(num_points, begin, end);
 
- 		AGraphValues sample_vals = AGraphValues();
- 		sample_vals.x_vals = x_vals;
- 		sample_vals.constants = constants;
- 		return sample_vals;
- 	}
+		AGraphValues sample_vals = AGraphValues();
+		sample_vals.x_vals = x_vals;
+		sample_vals.constants = constants;
+		return sample_vals;
+	}
 
- 	std::vector<Eigen::ArrayXXd> init_op_evals_x0(AGraphValues &sample_agraph_1_values) {
+	std::vector<Eigen::ArrayXXd> init_op_evals_x0(AGraphValues &sample_agraph_1_values) {
+		Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
 
- 		Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
+		double constant = sample_agraph_1_values.constants[0];
+		Eigen::ArrayXXd c_0 = constant * Eigen::ArrayXd::Ones(x_0.rows());
 
- 		double constant = sample_agraph_1_values.constants[0];
- 		Eigen::ArrayXXd c_0 = constant * Eigen::ArrayXd::Ones(x_0.rows());
+		std::vector<Eigen::ArrayXXd> op_evals_x0 = std::vector<Eigen::ArrayXXd>();
 
- 		std::vector<Eigen::ArrayXXd> op_evals_x0 = std::vector<Eigen::ArrayXXd>();
+		op_evals_x0.push_back(x_0);
+		op_evals_x0.push_back(c_0);
+		op_evals_x0.push_back(x_0+x_0);
+		op_evals_x0.push_back(x_0-x_0);
+		op_evals_x0.push_back(x_0*x_0);
+		op_evals_x0.push_back(x_0/x_0);
+		op_evals_x0.push_back(x_0.sin());
+		op_evals_x0.push_back(x_0.cos());
+		op_evals_x0.push_back(x_0.exp());
+		op_evals_x0.push_back(x_0.abs().log());
+		op_evals_x0.push_back(x_0.abs().pow(x_0));
+		op_evals_x0.push_back(x_0.abs());
+		op_evals_x0.push_back(x_0.abs().sqrt());
 
- 		op_evals_x0.push_back(x_0);
- 		op_evals_x0.push_back(c_0);
- 		op_evals_x0.push_back(x_0+x_0);
- 		op_evals_x0.push_back(x_0-x_0);
- 		op_evals_x0.push_back(x_0*x_0);
- 		op_evals_x0.push_back(x_0/x_0);
- 		op_evals_x0.push_back(x_0.sin());
- 		op_evals_x0.push_back(x_0.cos());
- 		op_evals_x0.push_back(x_0.exp());
- 		op_evals_x0.push_back(x_0.abs().log());
- 		op_evals_x0.push_back(x_0.abs().pow(x_0));
- 		op_evals_x0.push_back(x_0.abs());
- 		op_evals_x0.push_back(x_0.abs().sqrt());
+		return op_evals_x0;
+	}
 
- 		return op_evals_x0;
- 	}
+	std::vector<Eigen::ArrayXXd> init_op_x_derivs(AGraphValues &sample_agraph_1_values) {
+		Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
+		std::vector<Eigen::ArrayXXd> op_x_derivs = std::vector<Eigen::ArrayXXd>();
+		int size = x_0.rows();
 
- 	std::vector<Eigen::ArrayXXd> init_op_x_derivs(AGraphValues &sample_agraph_1_values) {
+		auto last_nan = [](Eigen::ArrayXXd array) {
+			array(array.rows() - 1, array.cols() -1) = std::nan("1");
+			Eigen::ArrayXXd modified_array = array;
+			return modified_array;
+		};
 
- 		Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
- 		std::vector<Eigen::ArrayXXd> op_x_derivs = std::vector<Eigen::ArrayXXd>();
- 		int size = x_0.rows();
+		op_x_derivs.push_back(Eigen::ArrayXd::Ones(size));
+		op_x_derivs.push_back(Eigen::ArrayXd::Zero(size));
+		op_x_derivs.push_back(2.0  * Eigen::ArrayXd::Ones(size));
+		op_x_derivs.push_back(Eigen::ArrayXd::Zero(size));
+		op_x_derivs.push_back(2.0 * x_0);
+		op_x_derivs.push_back(last_nan(Eigen::ArrayXd::Zero(size)));
+		op_x_derivs.push_back(x_0.cos());
+		op_x_derivs.push_back(-x_0.sin());
+		op_x_derivs.push_back(x_0.exp());
+		op_x_derivs.push_back(1.0 / x_0);
+		op_x_derivs.push_back(last_nan(x_0.abs().pow(x_0)*(x_0.abs().log() + Eigen::ArrayXd::Ones(size))));
+		op_x_derivs.push_back(x_0.sign());
+		op_x_derivs.push_back(0.5 * x_0.sign() / x_0.abs().sqrt());
 
- 		auto last_nan = [](Eigen::ArrayXXd array) {
- 			array(array.rows() - 1, array.cols() -1) = std::nan("1");
- 			Eigen::ArrayXXd modified_array = array;
- 			return modified_array;
- 		};
+		return op_x_derivs;
+	}
 
- 		op_x_derivs.push_back(Eigen::ArrayXd::Ones(size));
- 		op_x_derivs.push_back(Eigen::ArrayXd::Zero(size));
- 		op_x_derivs.push_back(2.0  * Eigen::ArrayXd::Ones(size));
- 		op_x_derivs.push_back(Eigen::ArrayXd::Zero(size));
- 		op_x_derivs.push_back(2.0 * x_0);
- 		op_x_derivs.push_back(last_nan(Eigen::ArrayXd::Zero(size)));
- 		op_x_derivs.push_back(x_0.cos());
- 		op_x_derivs.push_back(-x_0.sin());
- 		op_x_derivs.push_back(x_0.exp());
- 		op_x_derivs.push_back(1.0 / x_0);
- 		op_x_derivs.push_back(last_nan(x_0.abs().pow(x_0)*(x_0.abs().log() + Eigen::ArrayXd::Ones(size))));
- 		op_x_derivs.push_back(x_0.sign());
- 		op_x_derivs.push_back(0.5 * x_0.sign() / x_0.abs().sqrt());
+	std::vector<Eigen::ArrayXXd> init_op_c_derivs(AGraphValues &sample_agraph_1_values) {
 
- 		return op_x_derivs;
- 	}
+		int size = sample_agraph_1_values.x_vals.rows();
+		Eigen::ArrayXXd c_1 = sample_agraph_1_values.constants[1] * Eigen::ArrayXd::Ones(size);
+		std::vector<Eigen::ArrayXXd> op_c_derivs = std::vector<Eigen::ArrayXXd>();
 
- 	std::vector<Eigen::ArrayXXd> init_op_c_derivs(AGraphValues &sample_agraph_1_values) {
+		op_c_derivs.push_back(Eigen::ArrayXd::Zero(size));
+		op_c_derivs.push_back(Eigen::ArrayXd::Ones(size));
+		op_c_derivs.push_back(2.0  * Eigen::ArrayXd::Ones(size));
+		op_c_derivs.push_back(Eigen::ArrayXd::Zero(size));
+		op_c_derivs.push_back(2.0 * c_1);
+		op_c_derivs.push_back((Eigen::ArrayXd::Zero(size)));
+		op_c_derivs.push_back(c_1.cos());
+		op_c_derivs.push_back(-c_1.sin());
+		op_c_derivs.push_back(c_1.exp());
+		op_c_derivs.push_back(1.0 / c_1);
+		op_c_derivs.push_back(c_1.abs().pow(c_1)*(c_1.abs().log() + Eigen::ArrayXd::Ones(size)));
+		op_c_derivs.push_back(c_1.sign());
+		op_c_derivs.push_back(0.5 * c_1.sign() / c_1.abs().sqrt());
 
- 		int size = sample_agraph_1_values.x_vals.rows();
- 		Eigen::ArrayXXd c_1 = sample_agraph_1_values.constants[1] * Eigen::ArrayXd::Ones(size);
- 		std::vector<Eigen::ArrayXXd> op_c_derivs = std::vector<Eigen::ArrayXXd>();
-
- 		op_c_derivs.push_back(Eigen::ArrayXd::Zero(size));
- 		op_c_derivs.push_back(Eigen::ArrayXd::Ones(size));
- 		op_c_derivs.push_back(2.0  * Eigen::ArrayXd::Ones(size));
- 		op_c_derivs.push_back(Eigen::ArrayXd::Zero(size));
- 		op_c_derivs.push_back(2.0 * c_1);
- 		op_c_derivs.push_back((Eigen::ArrayXd::Zero(size)));
- 		op_c_derivs.push_back(c_1.cos());
- 		op_c_derivs.push_back(-c_1.sin());
- 		op_c_derivs.push_back(c_1.exp());
- 		op_c_derivs.push_back(1.0 / c_1);
- 		op_c_derivs.push_back(c_1.abs().pow(c_1)*(c_1.abs().log() + Eigen::ArrayXd::Ones(size)));
- 		op_c_derivs.push_back(c_1.sign());
- 		op_c_derivs.push_back(0.5 * c_1.sign() / c_1.abs().sqrt());
-
- 		return op_c_derivs;
- 	}
+		return op_c_derivs;
+	}
 };
 
 TEST_P(AGraphBackend, simplify_and_evaluate) {
-
 	int operator_i = GetParam();
 	Eigen::ArrayXXd expected_outcome = operator_evals_x0[operator_i];
 
 	Eigen::ArrayX3i stack(3, 3);
 	stack << 0, 0, 0,
-			 		 0, 1, 0,
-			 		 operator_i, 0, 0;
+					 0, 1, 0,
+					 operator_i, 0, 0;
 	Eigen::ArrayXXd f_of_x = SimplifyAndEvaluate(stack,
 															sample_agraph_1_values.x_vals,
 															sample_agraph_1_values.constants);
@@ -212,14 +208,14 @@ TEST_P(AGraphBackend, simplify_and_evaluate_x_deriv) {
 }
 
 TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {
-
 	int operator_i = GetParam();
 
 	int num_x_points = sample_agraph_1_values.x_vals.rows();
 	int num_consts = sample_agraph_1_values.constants.size();
 
 	int last_col = num_consts - 1;
-	Eigen::ArrayXXd expected_derivative = Eigen::MatrixXd::Zero(num_x_points, num_consts);
+	Eigen::ArrayXXd expected_derivative = 
+		Eigen::MatrixXd::Zero(num_x_points, num_consts);
 	expected_derivative.col(last_col) = operator_c_derivs[operator_i];
 
 	Eigen::ArrayX3i stack(4, 3);

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -77,10 +77,13 @@ class AGraphBackend : public ::testing::TestWithParam<int> {
  		op_evals_x0->push_back(x_0.cos());
  		op_evals_x0->push_back(x_0.exp());
  		op_evals_x0->push_back(x_0.abs().log());
- 		op_evals_x0->push_back(x_0.pow(x_0.abs()));
+ 		op_evals_x0->push_back(x_0.abs().pow(x_0));
  		op_evals_x0->push_back(x_0.abs());
  		op_evals_x0->push_back(x_0.abs().sqrt());
 
+ 		// for (int i=0; i<op_evals_x0->size(); i++) {
+ 		// 	std::cout << op_evals_x0->at(i) <<std::endl;
+ 		// }
  		return op_evals_x0;
  	}
 };

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -149,8 +149,27 @@ TEST_P(AGraphBackend, simplify_and_evaluate) {
 }
 
 TEST_P(AGraphBackend, simplify_and_evaluate_x_deriv) {
-	const int operator_i = GetParam();
-	ASSERT_TRUE(GetParam());
+	int operator_i = GetParam();
+
+	Eigen::ArrayXXd expected_derivative = operator_x_derivs[operator_i];
+
+	Eigen::ArrayX3i stack(4, 3);
+	stack << 0, 0, 0,
+					 0, 0, 0,
+					 0, 1, 1,
+					 operator_i, 0, 1;
+
+	Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
+	Eigen::ArrayXXd constants = sample_agraph_1_values.constants;
+	std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> res_and_gradient = 
+		SimplifyAndEvaluateWithDerivative(stack,
+																			x_0,
+																			constants,
+																			true);
+
+	Eigen::ArrayXXd df_dx = res_and_gradient.second;
+
+	ASSERT_TRUE(Eigen::MatrixXd(expected_derivative).isApprox(Eigen::MatrixXd(df_dx)));
 }
 
 TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -173,8 +173,33 @@ TEST_P(AGraphBackend, simplify_and_evaluate_x_deriv) {
 }
 
 TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {
-	const int operator_i = GetParam();
-	ASSERT_TRUE(GetParam());
+
+	int operator_i = GetParam();
+
+	int num_x_points = sample_agraph_1_values.x_vals.rows();
+	int num_consts = sample_agraph_1_values.constants.size();
+
+	int last_col = num_consts - 1;
+	Eigen::ArrayXXd expected_derivative = Eigen::MatrixXd::Zero(num_x_points, num_consts);
+	expected_derivative.col(last_col) = operator_c_derivs[operator_i];
+
+	Eigen::ArrayX3i stack(4, 3);
+	stack << 1, 1, 1,
+					 1, 1, 1,
+					 0, 1, 1,
+					 operator_i, 1, 0;
+
+	Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
+	Eigen::ArrayXXd constants = sample_agraph_1_values.constants;
+	std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> res_and_gradient = 
+		SimplifyAndEvaluateWithDerivative(stack,
+																			x_0,
+																			constants,
+																			false);
+
+	Eigen::ArrayXXd df_dx = res_and_gradient.second;
+
+	ASSERT_TRUE(Eigen::MatrixXd(expected_derivative).isApprox(Eigen::MatrixXd(df_dx)));
 }
 
 

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -208,35 +208,35 @@ TEST_P(AGraphBackend, simplify_and_evaluate_x_deriv) {
 }
 
 TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {
-	std::cout<<"1"<<std::endl;
+	
 	int operator_i = GetParam();
-	std::cout<<"2"<<std::endl;
+	
 	int num_x_points = sample_agraph_1_values.x_vals.rows();
 	int num_consts = sample_agraph_1_values.constants.size();
-	std::cout<<"3"<<std::endl;
+	
 	int last_col = num_consts - 1;
 	Eigen::ArrayXXd expected_derivative = 
 		Eigen::MatrixXd::Zero(num_x_points, num_consts).array();
-	std::cout<<"4"<<std::endl;
+	
 	expected_derivative.col(last_col) = operator_c_derivs[operator_i];
-	std::cout<<"5"<<std::endl;
+	
 	Eigen::ArrayX3i stack(4, 3);
 	stack << 1, 1, 1,
 					 1, 1, 1,
 					 0, 1, 1,
 					 operator_i, 1, 0;
-	std::cout<<"6"<<std::endl;
+	
 	Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
 	Eigen::ArrayXXd constants = sample_agraph_1_values.constants;
-	std::cout<<"7"<<std::endl;
+	
 	std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> res_and_gradient = 
 		SimplifyAndEvaluateWithDerivative(stack,
 																			x_0,
 																			constants,
-																				false);
-	std::cout<<"8"<<std::endl;
+																			false);
+	std::cout<<"20"<<std::endl;
 	Eigen::ArrayXXd df_dc = res_and_gradient.second;
-	std::cout<<"9"<<std::endl;
+	std::cout<<"21"<<std::endl;
 	ASSERT_TRUE(almostEqual(expected_derivative, df_dc));
 }
 

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -229,8 +229,7 @@ TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {
 	Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
 	Eigen::ArrayXXd constants = sample_agraph_1_values.constants;
 	std::cout<<"stack"<<std::endl;
-	std::cout<<stack<<std::endl;
-	std::endl;
+	std::cout<<stack<<std::endl<<std::endl;
 	std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> res_and_gradient = 
 		SimplifyAndEvaluateWithDerivative(stack,
 																			x_0,

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -215,7 +215,7 @@ TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {
 
 	int last_col = num_consts - 1;
 	Eigen::ArrayXXd expected_derivative = 
-		Eigen::MatrixXd::Zero(num_x_points, num_consts);
+		Eigen::MatrixXd::Zero(num_x_points, num_consts).array();
 	expected_derivative.col(last_col) = operator_c_derivs[operator_i];
 
 	Eigen::ArrayX3i stack(4, 3);

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -25,72 +25,64 @@ class AGraphBackend : public ::testing::TestWithParam<int> {
 	const int N_AGRAPH_VAL = 11;
 	const int N_OPS = 13;
 
-	AGraphValues *sample_agraph_1_values;
-	std::vector<Eigen::ArrayXXd> *operator_evals_x0;
-	std::vector<Eigen::ArrayXXd> *operator_x_derivs;
-	std::vector<Eigen::ArrayXXd> *operator_c_derivs;
-	Eigen::ArrayX3i sample_stack;
-	Eigen::ArrayX3i all_funcs_stack;
+	AGraphValues sample_agraph_1_values;
+	std::vector<Eigen::ArrayXXd> operator_evals_x0;
+	std::vector<Eigen::ArrayXXd> operator_x_derivs;
+	std::vector<Eigen::ArrayXXd> operator_c_derivs;
 
   virtual void SetUp() {
   	sample_agraph_1_values = init_agraph_vals(AGRAPH_VAL_START,
-  																						 AGRAPH_VAL_END,
-  																						 N_AGRAPH_VAL);
+											  AGRAPH_VAL_END,
+											  N_AGRAPH_VAL);
   	operator_evals_x0 = init_op_evals_x0(sample_agraph_1_values);
   	operator_x_derivs = init_op_x_derivs(sample_agraph_1_values);
   	operator_c_derivs = init_op_c_derivs(sample_agraph_1_values);
-  	sample_stack = init_sample_stack();
-  	all_funcs_stack = init_all_funcs_stack();
   }
-  virtual void TearDown() {
-  	delete operator_c_derivs;
-  	delete operator_x_derivs;
-  	delete operator_evals_x0;
-  	delete sample_agraph_1_values;
-  }
+  virtual void TearDown() {}
+
  private:
- 	AGraphValues *init_agraph_vals(double begin, double end, int num_points) {
+ 	AGraphValues init_agraph_vals(double begin, double end, int num_points) {
  		Eigen::VectorXd constants = Eigen::VectorXd(2);
  		constants << 10, 3.14;
 
  		Eigen::ArrayXXd x_vals(num_points, 1);
  		x_vals = Eigen::ArrayXd::LinSpaced(num_points, begin, end);
- 		AGraphValues *sample_vals = new AGraphValues();
- 		sample_vals->x_vals = x_vals;
- 		sample_vals->constants = constants;
+ 		AGraphValues sample_vals = AGraphValues();
+ 		sample_vals.x_vals = x_vals;
+ 		sample_vals.constants = constants;
  		return sample_vals;
  	}
 
- 	std::vector<Eigen::ArrayXXd> *init_op_evals_x0(AGraphValues *sample_agraph_1_values) {
+ 	std::vector<Eigen::ArrayXXd> init_op_evals_x0(AGraphValues &sample_agraph_1_values) {
 
- 		Eigen::ArrayXXd x_0 = sample_agraph_1_values->x_vals;
+ 		Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
 
- 		double constant = sample_agraph_1_values->constants[0];
+ 		double constant = sample_agraph_1_values.constants[0];
  		Eigen::ArrayXXd c_0 = constant * Eigen::ArrayXd::Ones(x_0.rows());
 
- 		std::vector<Eigen::ArrayXXd> *op_evals_x0 = new std::vector<Eigen::ArrayXXd>();
+ 		std::vector<Eigen::ArrayXXd> op_evals_x0 = std::vector<Eigen::ArrayXXd>();
 
- 		op_evals_x0->push_back(x_0);
- 		op_evals_x0->push_back(c_0);
- 		op_evals_x0->push_back(x_0+x_0);
- 		op_evals_x0->push_back(x_0-x_0);
- 		op_evals_x0->push_back(x_0*x_0);
- 		op_evals_x0->push_back(x_0/x_0);
- 		op_evals_x0->push_back(x_0.sin());
- 		op_evals_x0->push_back(x_0.cos());
- 		op_evals_x0->push_back(x_0.exp());
- 		op_evals_x0->push_back(x_0.abs().log());
- 		op_evals_x0->push_back(x_0.abs().pow(x_0));
- 		op_evals_x0->push_back(x_0.abs());
- 		op_evals_x0->push_back(x_0.abs().sqrt());
+ 		op_evals_x0.push_back(x_0);
+ 		op_evals_x0.push_back(c_0);
+ 		op_evals_x0.push_back(x_0+x_0);
+ 		op_evals_x0.push_back(x_0-x_0);
+ 		op_evals_x0.push_back(x_0*x_0);
+ 		op_evals_x0.push_back(x_0/x_0);
+ 		op_evals_x0.push_back(x_0.sin());
+ 		op_evals_x0.push_back(x_0.cos());
+ 		op_evals_x0.push_back(x_0.exp());
+ 		op_evals_x0.push_back(x_0.abs().log());
+ 		op_evals_x0.push_back(x_0.abs().pow(x_0));
+ 		op_evals_x0.push_back(x_0.abs());
+ 		op_evals_x0.push_back(x_0.abs().sqrt());
 
  		return op_evals_x0;
  	}
 
- 	std::vector<Eigen::ArrayXXd> *init_op_x_derivs(AGraphValues *sample_agraph_1_values) {
+ 	std::vector<Eigen::ArrayXXd> init_op_x_derivs(AGraphValues &sample_agraph_1_values) {
 
- 		Eigen::ArrayXXd x_0 = sample_agraph_1_values->x_vals;
- 		std::vector<Eigen::ArrayXXd> *op_x_derivs = new std::vector<Eigen::ArrayXXd>();
+ 		Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
+ 		std::vector<Eigen::ArrayXXd> op_x_derivs = std::vector<Eigen::ArrayXXd>();
  		int size = x_0.rows();
 
  		auto last_nan = [](Eigen::ArrayXXd array) {
@@ -99,89 +91,61 @@ class AGraphBackend : public ::testing::TestWithParam<int> {
  			return modified_array;
  		};
 
- 		op_x_derivs->push_back(Eigen::ArrayXd::Ones(size));
- 		op_x_derivs->push_back(Eigen::ArrayXd::Zero(size));
- 		op_x_derivs->push_back(2.0  * Eigen::ArrayXd::Ones(size));
- 		op_x_derivs->push_back(Eigen::ArrayXd::Zero(size));
- 		op_x_derivs->push_back(2.0 * x_0);
- 		op_x_derivs->push_back(last_nan(Eigen::ArrayXd::Zero(size)));
- 		op_x_derivs->push_back(x_0.cos());
- 		op_x_derivs->push_back(-x_0.sin());
- 		op_x_derivs->push_back(x_0.exp());
- 		op_x_derivs->push_back(1.0 / x_0);
- 		op_x_derivs->push_back(last_nan(x_0.abs().pow(x_0)*(x_0.abs().log() + Eigen::ArrayXd::Ones(size))));
- 		op_x_derivs->push_back(x_0.sign());
- 		op_x_derivs->push_back(0.5 * x_0.sign() / x_0.abs().sqrt());
+ 		op_x_derivs.push_back(Eigen::ArrayXd::Ones(size));
+ 		op_x_derivs.push_back(Eigen::ArrayXd::Zero(size));
+ 		op_x_derivs.push_back(2.0  * Eigen::ArrayXd::Ones(size));
+ 		op_x_derivs.push_back(Eigen::ArrayXd::Zero(size));
+ 		op_x_derivs.push_back(2.0 * x_0);
+ 		op_x_derivs.push_back(last_nan(Eigen::ArrayXd::Zero(size)));
+ 		op_x_derivs.push_back(x_0.cos());
+ 		op_x_derivs.push_back(-x_0.sin());
+ 		op_x_derivs.push_back(x_0.exp());
+ 		op_x_derivs.push_back(1.0 / x_0);
+ 		op_x_derivs.push_back(last_nan(x_0.abs().pow(x_0)*(x_0.abs().log() + Eigen::ArrayXd::Ones(size))));
+ 		op_x_derivs.push_back(x_0.sign());
+ 		op_x_derivs.push_back(0.5 * x_0.sign() / x_0.abs().sqrt());
 
  		return op_x_derivs;
  	}
 
- 	std::vector<Eigen::ArrayXXd> *init_op_c_derivs(AGraphValues *sample_agraph_1_values) {
+ 	std::vector<Eigen::ArrayXXd> init_op_c_derivs(AGraphValues &sample_agraph_1_values) {
 
- 		int size = sample_agraph_1_values->x_vals.rows();
- 		Eigen::ArrayXXd c_1 = sample_agraph_1_values->constants[1] * Eigen::ArrayXd::Ones(size);
- 		std::vector<Eigen::ArrayXXd> *op_c_derivs = new std::vector<Eigen::ArrayXXd>();
+ 		int size = sample_agraph_1_values.x_vals.rows();
+ 		Eigen::ArrayXXd c_1 = sample_agraph_1_values.constants[1] * Eigen::ArrayXd::Ones(size);
+ 		std::vector<Eigen::ArrayXXd> op_c_derivs = std::vector<Eigen::ArrayXXd>();
 
- 		op_c_derivs->push_back(Eigen::ArrayXd::Zero(size));
- 		op_c_derivs->push_back(Eigen::ArrayXd::Ones(size));
- 		op_c_derivs->push_back(2.0  * Eigen::ArrayXd::Ones(size));
- 		op_c_derivs->push_back(Eigen::ArrayXd::Zero(size));
- 		op_c_derivs->push_back(2.0 * c_1);
- 		op_c_derivs->push_back((Eigen::ArrayXd::Zero(size)));
- 		op_c_derivs->push_back(c_1.cos());
- 		op_c_derivs->push_back(-c_1.sin());
- 		op_c_derivs->push_back(c_1.exp());
- 		op_c_derivs->push_back(1.0 / c_1);
- 		op_c_derivs->push_back(c_1.abs().pow(c_1)*(c_1.abs().log() + Eigen::ArrayXd::Ones(size)));
- 		op_c_derivs->push_back(c_1.sign());
- 		op_c_derivs->push_back(0.5 * c_1.sign() / c_1.abs().sqrt());
+ 		op_c_derivs.push_back(Eigen::ArrayXd::Zero(size));
+ 		op_c_derivs.push_back(Eigen::ArrayXd::Ones(size));
+ 		op_c_derivs.push_back(2.0  * Eigen::ArrayXd::Ones(size));
+ 		op_c_derivs.push_back(Eigen::ArrayXd::Zero(size));
+ 		op_c_derivs.push_back(2.0 * c_1);
+ 		op_c_derivs.push_back((Eigen::ArrayXd::Zero(size)));
+ 		op_c_derivs.push_back(c_1.cos());
+ 		op_c_derivs.push_back(-c_1.sin());
+ 		op_c_derivs.push_back(c_1.exp());
+ 		op_c_derivs.push_back(1.0 / c_1);
+ 		op_c_derivs.push_back(c_1.abs().pow(c_1)*(c_1.abs().log() + Eigen::ArrayXd::Ones(size)));
+ 		op_c_derivs.push_back(c_1.sign());
+ 		op_c_derivs.push_back(0.5 * c_1.sign() / c_1.abs().sqrt());
 
  		return op_c_derivs;
- 	}
-
- 	Eigen::ArrayX3i init_sample_stack() {
- 		Eigen::ArrayX3i test_stack= Eigen::ArrayX3i(3, 3);
- 		test_stack << 0, 0, 0,
- 										 1, 0, 0,
- 										 2, 0, 1,
- 										 6, 0, 2,
- 										 2, 3, 1;
- 		return test_stack;
- 	}
-
- 	Eigen::ArrayX3i init_all_funcs_stack() {
- 		Eigen::ArrayX3i test_stack = Eigen::ArrayX3i(13, 3);
- 		test_stack << 0, 0, 0,
- 									1, 0, 0,
- 									2, 1, 0,
- 									3, 2, 1,
- 									4, 3, 0,
- 									5, 4, 0,
- 									6, 5, 0,
- 									7, 6, 0,
- 									8, 7, 0,
- 									9, 8, 0,
- 									10, 9, 0,
- 									11, 10, 0,
- 									12, 11, 0;
- 		return test_stack;
  	}
 };
 
 TEST_P(AGraphBackend, simplify_and_evaluate) {
 
 	int operator_i = GetParam();
-	Eigen::ArrayXXd expected_outcome = (*operator_evals_x0)[operator_i];
+	Eigen::ArrayXXd expected_outcome = operator_evals_x0[operator_i];
 
 	Eigen::ArrayX3i stack(3, 3);
 	stack << 0, 0, 0,
-					 0, 1, 0,
-					 operator_i, 0, 0;
+			 		 0, 1, 0,
+			 		 operator_i, 0, 0;
 	Eigen::ArrayXXd f_of_x = SimplifyAndEvaluate(stack,
-															sample_agraph_1_values->x_vals,
-															sample_agraph_1_values->constants);
-	ASSERT_TRUE(GetParam());
-	// ASSERT_(ASSERT_NEAR(expected_outcome, f_of_x, TOL));
+															sample_agraph_1_values.x_vals,
+															sample_agraph_1_values.constants);
+
+	ASSERT_TRUE(Eigen::MatrixXd(expected_outcome).isApprox(Eigen::MatrixXd(f_of_x)));
 }
 
 TEST_P(AGraphBackend, simplify_and_evaluate_x_deriv) {

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -228,7 +228,9 @@ TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {
 	
 	Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
 	Eigen::ArrayXXd constants = sample_agraph_1_values.constants;
-	
+	std::cout<<"stack"<<std::endl;
+	std::cout<<stack<<std::endl;
+	std::endl;
 	std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> res_and_gradient = 
 		SimplifyAndEvaluateWithDerivative(stack,
 																			x_0,

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -208,32 +208,35 @@ TEST_P(AGraphBackend, simplify_and_evaluate_x_deriv) {
 }
 
 TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {
+	std::cout<<"1"<<std::endl;
 	int operator_i = GetParam();
-
+	std::cout<<"2"<<std::endl;
 	int num_x_points = sample_agraph_1_values.x_vals.rows();
 	int num_consts = sample_agraph_1_values.constants.size();
-
+	std::cout<<"3"<<std::endl;
 	int last_col = num_consts - 1;
 	Eigen::ArrayXXd expected_derivative = 
 		Eigen::MatrixXd::Zero(num_x_points, num_consts).array();
+	std::cout<<"4"<<std::endl;
 	expected_derivative.col(last_col) = operator_c_derivs[operator_i];
-
+	std::cout<<"5"<<std::endl;
 	Eigen::ArrayX3i stack(4, 3);
 	stack << 1, 1, 1,
 					 1, 1, 1,
 					 0, 1, 1,
 					 operator_i, 1, 0;
-
+	std::cout<<"6"<<std::endl;
 	Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
 	Eigen::ArrayXXd constants = sample_agraph_1_values.constants;
+	std::cout<<"7"<<std::endl;
 	std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> res_and_gradient = 
 		SimplifyAndEvaluateWithDerivative(stack,
 																			x_0,
 																			constants,
-																			false);
-
+																				false);
+	std::cout<<"8"<<std::endl;
 	Eigen::ArrayXXd df_dc = res_and_gradient.second;
-
+	std::cout<<"9"<<std::endl;
 	ASSERT_TRUE(almostEqual(expected_derivative, df_dc));
 }
 


### PR DESCRIPTION
This feature contains the code for testing the C++ backend for the AGraph. This includes tests that mirror those in the python backend tests. The functions tested include SimplifyAndEvaluate, SimplifyAndEvaluateWithDerivative with respect to x and constants. Also, included some missing headers in BingoCpp/utils and fixed function call to isnan.