### PR TITLE
removed mask from evaluate/evaluateWithDerivative

### DIFF
--- a/include/BingoCpp/backend.h
+++ b/include/BingoCpp/backend.h
@@ -9,7 +9,6 @@
 #include <Eigen/Core>
 
 namespace bingo {
-
 /*!
  * \brief Identify whether a c++ backend is being used in python module.
  *


### PR DESCRIPTION
This contains the new implementation of evaulate and evaulate with derivative that uses the short cached stack in agraph