### PR TITLE
Agraph sync

### DIFF
--- a/app/bingocpp_pymodule.cpp
+++ b/app/bingocpp_pymodule.cpp
@@ -78,9 +78,12 @@ PYBIND11_MODULE(bingocpp, m) {
   m.def("rand_init", &rand_init);
 
   py::class_<AGraph>(m, "AGraph")
-    .def(py::init<bool &>(), py::arg("manual_constants") = false)
+    .def(py::init<bool &, AGraph *>(),
+        py::arg("manual_constants") = false,
+        py::arg("agraph_copy") = nullptr)
+    .def("is_cpp", &AGraph::IsCpp)
     .def_property("command_array",
-                  &AGraph::GetCommandArray,
+                  &AGraph::GetCommandArrayModifiable,
                   &AGraph::SetCommandArray)
     .def_property("fitness",
                   &AGraph::GetFitness,
@@ -88,17 +91,25 @@ PYBIND11_MODULE(bingocpp, m) {
     .def_property("fit_set",
                   &AGraph::IsFitnessSet,
                   &AGraph::SetFitness)
+    .def_property("genetic_age",
+                  &AGraph::GetGeneticAge,
+                  &AGraph::SetGeneticAge)
+    .def_property("constants",
+                  &AGraph::GetLocalOptimizationParamsModifiable,
+                  &AGraph::SetLocalOptimizationParams)
     .def("notify_command_array_modification",
          &AGraph::NotifyCommandArrayModificiation)
     .def("needs_local_optimization", &AGraph::NeedsLocalOptimization)
     .def("get_utilized_commands", &AGraph::GetUtilizedCommands)
     .def("get_number_local_optimization_params",
         &AGraph::GetNumberLocalOptimizationParams)
+    .def("get_local_optimization_params",
+        &AGraph::GetLocalOptimizationParamsModifiable)
     .def("set_local_optimization_params", &AGraph::SetLocalOptimizationParams)
     .def("evaluate_equation_at", &AGraph::EvaluateEquationAt)
     .def("evaluate_equation_with_x_gradient_at",
         &AGraph::EvaluateEquationWithXGradientAt)
-    .def("evaluate_equation_with_local_opt_gradient",
+    .def("evaluate_equation_with_local_opt_gradient_at",
         &AGraph::EvaluateEquationWithLocalOptGradientAt)
     .def("__str__", &AGraph::GetConsoleString)
     .def("get_latex_string", &AGraph::GetLatexString)

--- a/app/bingocpp_pymodule.cpp
+++ b/app/bingocpp_pymodule.cpp
@@ -45,6 +45,7 @@
 
 #include "BingoCpp/acyclic_graph.h"
 #include "BingoCpp/backend.h"
+#include "BingoCpp/agraph.h"
 #include "BingoCpp/graph_manip.h"
 #include "BingoCpp/fitness_metric.h"
 #include "BingoCpp/training_data.h"
@@ -58,7 +59,7 @@ namespace py = pybind11;
 using namespace bingo;
 
 PYBIND11_MODULE(bingocpp, m) {
-  m.doc() = "pybind11 example plugin";  // optional module docstring
+  m.doc() = "bingocpp module";  // optional module docstring
   m.def("is_cpp", &backend::IsCpp, "is the backend c++");
   m.def("evaluate", &backend::Evaluate, "evaluate");
   m.def("simplify_and_evaluate", &backend::SimplifyAndEvaluate,
@@ -73,9 +74,40 @@ PYBIND11_MODULE(bingocpp, m) {
         "get the commands that are utilized in a stack");
   m.def("simplify_stack", &backend::SimplifyStack,
         "simplify stack to only utilized commands");
-        
-        
+
   m.def("rand_init", &rand_init);
+
+  py::class_<AGraph>(m, "AGraph")
+    .def(py::init<bool &>(), py::arg("manual_constants") = false)
+    .def_property("command_array",
+                  &AGraph::GetCommandArray,
+                  &AGraph::SetCommandArray)
+    .def_property("fitness",
+                  &AGraph::GetFitness,
+                  &AGraph::SetFitness)
+    .def_property("fit_set",
+                  &AGraph::IsFitnessSet,
+                  &AGraph::SetFitness)
+    .def("notify_command_array_modification",
+         &AGraph::NotifyCommandArrayModificiation)
+    .def("needs_local_optimization", &AGraph::NeedsLocalOptimization)
+    .def("get_utilized_commands", &AGraph::GetUtilizedCommands)
+    .def("get_number_local_optimization_params",
+        &AGraph::GetNumberLocalOptimizationParams)
+    .def("set_local_optimization_params", &AGraph::SetLocalOptimizationParams)
+    .def("evaluate_equation_at", &AGraph::EvaluateEquationAt)
+    .def("evaluate_equation_with_x_gradient_at",
+        &AGraph::EvaluateEquationWithXGradientAt)
+    .def("evaluate_equation_with_local_opt_gradient",
+        &AGraph::EvaluateEquationWithLocalOptGradientAt)
+    .def("__str__", &AGraph::GetConsoleString)
+    .def("get_latex_string", &AGraph::GetLatexString)
+    .def("get_console_string", &AGraph::GetConsoleString)
+    .def("get_stack_string", &AGraph::GetStackString)
+    .def("get_complexity", &AGraph::GetComplexity)
+    .def("distance", &AGraph::Distance)
+    .def("copy", &AGraph::Copy);
+
   py::class_<AcyclicGraph>(m, "AcyclicGraph")
   .def(py::init<>())
   .def(py::init<AcyclicGraph &>())
@@ -96,6 +128,7 @@ PYBIND11_MODULE(bingocpp, m) {
   .def("utilized_commands", &AcyclicGraph::utilized_commands)
   .def("complexity", &AcyclicGraph::complexity)
   .def("__str__", &AcyclicGraph::print_stack);
+
   py::class_<AcyclicGraphManipulator>(m, "AcyclicGraphManipulator")
   .def(py::init<int &, int &, int &, float &, float &, int &>(),
        py::arg("nvars") = 3, py::arg("ag_size") = 15, py::arg("nloads") = 1,
@@ -147,8 +180,3 @@ PYBIND11_MODULE(bingocpp, m) {
   m.def("GramPoly", &GramPoly);
   m.def("GramWeight", &GramWeight);
 }
-
-
-
-
-

--- a/app/bingocpp_pymodule.cpp
+++ b/app/bingocpp_pymodule.cpp
@@ -59,19 +59,19 @@ using namespace bingo;
 
 PYBIND11_MODULE(bingocpp, m) {
   m.doc() = "pybind11 example plugin";  // optional module docstring
-  m.def("is_cpp", &backend::isCpp, "is the backend c++");
-  m.def("evaluate", &backend::evaluate, "evaluate");
-  m.def("simplify_and_evaluate", &backend::simplifyAndEvaluate,
+  m.def("is_cpp", &backend::IsCpp, "is the backend c++");
+  m.def("evaluate", &backend::Evaluate, "evaluate");
+  m.def("simplify_and_evaluate", &backend::SimplifyAndEvaluate,
         "evaluate after simplification");
-  m.def("evaluate_with_derivative", &backend::evaluateWithDerivative,
+  m.def("evaluate_with_derivative", &backend::EvaluateWithDerivative,
         "evaluate with derivative");
   m.def("simplify_and_evaluate_with_derivative",
-        &backend::simplifyAndEvaluateWithDerivative,
+        &backend::SimplifyAndEvaluateWithDerivative,
         "evaluate with derivative after simplification");
   m.def("get_utilized_commands",
-        &backend::getUtilizedCommands,
+        &backend::GetUtilizedCommands,
         "get the commands that are utilized in a stack");
-  m.def("simplify_stack", &backend::simplifyStack,
+  m.def("simplify_stack", &backend::SimplifyStack,
         "simplify stack to only utilized commands");
         
         

--- a/app/driver.cpp
+++ b/app/driver.cpp
@@ -113,7 +113,7 @@ void TestAcyclicGraph(int num_loops, int num_evals) {
     t1 = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < num_evals; ++i) {
-      y = bingo::backend::evaluate(stack, x, constants);
+      y = bingo::backend::Evaluate(stack, x, constants);
     }
 
     t2 = std::chrono::high_resolution_clock::now();
@@ -122,7 +122,7 @@ void TestAcyclicGraph(int num_loops, int num_evals) {
     t1 = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < num_evals; ++i) {
-      y = bingo::backend::evaluate(simple_stack, x, constants);
+      y = bingo::backend::Evaluate(simple_stack, x, constants);
     }
 
     t2 = std::chrono::high_resolution_clock::now();
@@ -131,7 +131,7 @@ void TestAcyclicGraph(int num_loops, int num_evals) {
     t1 = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < num_evals; ++i) {
-      y_and_dy = bingo::backend::evaluateWithDerivative(stack, x, constants);
+      y_and_dy = bingo::backend::EvaluateWithDerivative(stack, x, constants);
     }
 
     t2 = std::chrono::high_resolution_clock::now();
@@ -140,7 +140,7 @@ void TestAcyclicGraph(int num_loops, int num_evals) {
     t1 = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < num_evals; ++i) {
-      y_and_dy = bingo::backend::evaluateWithDerivative(simple_stack, x, constants);
+      y_and_dy = bingo::backend::EvaluateWithDerivative(simple_stack, x, constants);
     }
 
     t2 = std::chrono::high_resolution_clock::now();

--- a/app/performance_benchmarks.cpp
+++ b/app/performance_benchmarks.cpp
@@ -108,7 +108,7 @@ void benchmark_evaluate(const std::vector<AGraphValues>& indv_list,
                         const Eigen::ArrayXXd& x_vals) {
   std::vector<AGraphValues>::const_iterator indv;
   for(indv=indv_list.begin(); indv!=indv_list.end(); indv++) {
-    bingo::backend::simplifyAndEvaluate(indv->command_array,
+    bingo::backend::SimplifyAndEvaluate(indv->command_array,
                                         x_vals,
                                         indv->constants);
   } 
@@ -118,7 +118,7 @@ void benchmark_evaluate_w_x_derivative(const std::vector<AGraphValues>& indv_lis
                                        const Eigen::ArrayXXd& x_vals) {
   std::vector<AGraphValues>::const_iterator indv;
   for(indv=indv_list.begin(); indv!=indv_list.end(); indv++) {
-    bingo::backend::simplifyAndEvaluateWithDerivative(indv->command_array,
+    bingo::backend::SimplifyAndEvaluateWithDerivative(indv->command_array,
                                                       x_vals,
                                                       indv->constants,
                                                       true);
@@ -129,7 +129,7 @@ void benchmark_evaluate_w_c_derivative(const std::vector<AGraphValues>& indv_lis
                                        const Eigen::ArrayXXd& x_vals) {
   std::vector<AGraphValues>::const_iterator indv;
   for(indv=indv_list.begin(); indv!=indv_list.end(); indv++) {
-    bingo::backend::simplifyAndEvaluateWithDerivative(indv->command_array,
+    bingo::backend::SimplifyAndEvaluateWithDerivative(indv->command_array,
                                                       x_vals,
                                                       indv->constants,
                                                       false);

--- a/include/BingoCpp/agraph.h
+++ b/include/BingoCpp/agraph.h
@@ -65,7 +65,7 @@ class AGraph {
    * 
    * @return Eigen::ArrayX3i The command array for this graph.
    */
-  Eigen::ArrayX3i GetCommandArray() const;
+  const Eigen::ArrayX3i& GetCommandArray() const;
   
   /**
    * @brief Set the Command Array object

--- a/include/BingoCpp/agraph.h
+++ b/include/BingoCpp/agraph.h
@@ -51,12 +51,17 @@ class AGraph {
    */
   AGraph Copy();
 
+  inline bool IsCpp() { return true; }
+
   /**
    * @brief Get the Command Array object
    * 
    * @return Eigen::ArrayX3i The command array for this graph.
    */
   const Eigen::ArrayX3i& GetCommandArray() const;
+
+
+  Eigen::ArrayX3i& GetCommandArrayModifiable();
   
   /**
    * @brief Set the Command Array object
@@ -158,7 +163,9 @@ class AGraph {
    * 
    * @return Eigen::VectorXd The constants in the AGraph
    */
-  Eigen::VectorXd GetLocalOptimizationParams() const;
+  const Eigen::VectorXd& GetLocalOptimizationParams() const;
+
+  Eigen::VectorXd& GetLocalOptimizationParamsModifiable();
 
   /**
    * @brief Evaluate the AGraph equatoin

--- a/include/BingoCpp/agraph.h
+++ b/include/BingoCpp/agraph.h
@@ -27,6 +27,7 @@
 #include <Eigen/Core>
 
 typedef std::unordered_map<int, std::string> PrintMap;
+typedef std::vector<std::vector<std::string>> PrintVector;
 typedef std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvalAndDerivative;
 
 namespace bingo {
@@ -39,7 +40,16 @@ namespace bingo {
  */
 class AGraph {
  public:
-  AGraph();
+  AGraph(
+      Eigen::ArrayX3i command_array = Eigen::ArrayX3i(0, 3),
+      Eigen::ArrayX3i short_command_array = Eigen::ArrayX3i(0, 3),
+      Eigen::VectorXd constants = Eigen::VectorXd(0),
+      int num_constants = 0,
+      bool manual_constants = false,
+      int needs_opt = false,
+      double fitness = 1e9,
+      bool fit_set = false,
+      int genetic_age = 0);
 
   AGraph(const AGraph& agraph);
 
@@ -225,6 +235,10 @@ class AGraph {
    */
   int GetComplexity() const;
 
+  void ForceRenumberConstants();
+
+  int Distance(const AGraph& agraph);
+
   /**
    * @brief Determines if the equation operation has arity two.
    * 
@@ -249,6 +263,7 @@ class AGraph {
   Eigen::VectorXd constants_;
   bool needs_opt_;
   int num_constants_;
+  bool manual_constants_ = false;
   double fitness_;
   bool fit_set_;
   int genetic_age_;

--- a/include/BingoCpp/agraph.h
+++ b/include/BingoCpp/agraph.h
@@ -14,8 +14,8 @@
  * License for the specific language governing permissions and limitations under 
  * the License.
 */
-#ifndef INCLUDE_BINGOCPP_AGRAPH_H_
-#define INCLUDE_BINGOCPP_AGRAPH_H_
+#ifndef BINGOCPP_INCLUDE_BINGOCPP_AGRAPH_H_
+#define BINGOCPP_INCLUDE_BINGOCPP_AGRAPH_H_
 
 #include <set>
 #include <unordered_map>
@@ -48,41 +48,41 @@ class AGraph {
    * 
    * @return AGraph
    */
-  AGraph copy();
+  AGraph Copy();
 
   /**
    * @brief Get the Command Array object
    * 
    * @return Eigen::ArrayX3i The command array for this graph.
    */
-  Eigen::ArrayX3i getCommandArray() const;
+  Eigen::ArrayX3i GetCommandArray() const;
   
   /**
    * @brief Set the Command Array object
    * 
    * @param command_array A copy of the new Command Array
    */
-  void setCommandArray(Eigen::ArrayX3i command_array);
+  void SetCommandArray(Eigen::ArrayX3i command_array);
 
   /**
    * @brief Nofity individual of inplace modification of command array.
    * 
    */
-  void notifyCommandArrayModificiation();
+  void NotifyCommandArrayModificiation();
 
   /**
    * @brief Get the Fitness of this AGraph
    * 
    * @return double 
    */
-  double getFitness() const;
+  double GetFitness() const;
 
   /**
    * @brief Set the Fitness for this AGraph
    * 
    * @param fitness 
    */
-  void setFitness(double fitness);
+  void SetFitness(double fitness);
 
   /**
    * @brief Check if fitness has been set for this AGraph object.
@@ -90,21 +90,21 @@ class AGraph {
    * @return true if set
    * @return false otherwise
    */
-  bool isFitnessSet() const;
+  bool IsFitnessSet() const;
 
   /**
    * @brief Set the Genetic Age of this AGraph
    * 
    * @param age The age of this AGraph
    */
-  void setGeneticAge(const int age);
+  void SetGeneticAge(const int age);
 
   /**
    * @brief Get the Genetic Age of this AGraph
    * 
    * @return int 
    */
-  int getGeneticAge() const;
+  int GetGeneticAge() const;
 
   /**
    * @brief Get the Utilized Commands for the CommandArray
@@ -115,7 +115,7 @@ class AGraph {
    * 
    * @return std::vector<bool> The mask.
    */
-  std::vector<bool> getUtilizedCommands() const;
+  std::vector<bool> GetUtilizedCommands() const;
 
   /**
    * @brief The AGraph needs local optimization.
@@ -125,7 +125,7 @@ class AGraph {
    * @return true Needs optimization.
    * @return false Has been optimized
    */
-  bool needsLocalOptimization() const;
+  bool NeedsLocalOptimization() const;
 
   /**
    * @brief Get the Number Local Optimization Params
@@ -135,7 +135,7 @@ class AGraph {
    * 
    * @return int The number of parameters to optimize.
    */
-  int getNumberLocalOptimizationParams() const;
+  int GetNumberLocalOptimizationParams() const;
 
   /**
    * @brief Set the Local Optimization Params
@@ -144,7 +144,7 @@ class AGraph {
    * 
    * @param params The optimized constants.
    */
-  void setLocalOptimizationParams(Eigen::VectorXd params);
+  void SetLocalOptimizationParams(Eigen::VectorXd params);
 
   /**
    * @brief Get the constants in the graph.
@@ -154,7 +154,7 @@ class AGraph {
    * 
    * @return Eigen::VectorXd The constants in the AGraph
    */
-  Eigen::VectorXd getLocalOptimizationParams() const;
+  Eigen::VectorXd GetLocalOptimizationParams() const;
 
   /**
    * @brief Evaluate the AGraph equatoin
@@ -166,7 +166,7 @@ class AGraph {
    * 
    * @return Eigen::ArrayXXd The evaluation of function at points x.
    */
-  Eigen::ArrayXXd evaluateEquationAt(Eigen::ArrayXXd& x);
+  Eigen::ArrayXXd EvaluateEquationAt(Eigen::ArrayXXd& x);
 
   /**
    * @brief Evaluate the AGraph and get its derivatives
@@ -180,7 +180,7 @@ class AGraph {
    * @return EvalAndDerivative The evaluation of the function of this AGraph
    * along the points x and the derivative of the equation with respect to x.
    */
-  EvalAndDerivative evaluateEquationWithXGradientAt(Eigen::ArrayXXd& x);
+  EvalAndDerivative EvaluateEquationWithXGradientAt(Eigen::ArrayXXd& x);
 
   /**
    * @brief Evluate the AGraph and get its derivatives.
@@ -195,35 +195,35 @@ class AGraph {
    * along the points x and the derivative of the equation with respect to 
    * the constants of the equation.
    */
-  EvalAndDerivative evaluateEquationWithLocalOptGradientAt(Eigen::ArrayXXd& x);
+  EvalAndDerivative EvaluateEquationWithLocalOptGradientAt(Eigen::ArrayXXd& x);
 
   /**
    * @brief Get the Latex String of this AGraph equation.
    * 
    * @return std::string 
    */
-  std::string getLatexString() const;
+  std::string GetLatexString() const;
 
   /**
    * @brief Get the Console String this AGraph equation.
    * 
    * @return std::string 
    */
-  std::string getConsoleString() const;
+  std::string GetConsoleString() const;
 
   /**
    * @brief Get the Stack String this AGraph equation.
    * 
    * @return std::string 
    */
-  std::string getStackString() const;
+  std::string GetStackString() const;
 
   /**
    * @brief Get the Complexity of this AGraph equation.
    * 
    * @return int 
    */
-  int getComplexity() const;
+  int GetComplexity() const;
 
   /**
    * @brief Determines if the equation operation has arity two.
@@ -232,7 +232,7 @@ class AGraph {
    * @return true If the operation requires to parameters.
    * @return false Otherwise.
    */
-  static bool hasArityTwo(int node);
+  static bool HasArityTwo(int node);
 
   /**
    * @brief Determines if the equation operation is loading a value.
@@ -241,7 +241,7 @@ class AGraph {
    * @return true If the node loads a value.
    * @return false It has arity greater than 0.
    */
-  static bool isTerminal(int node);
+  static bool IsTerminal(int node);
 
  private:
   Eigen::ArrayX3i command_array_;
@@ -268,4 +268,4 @@ class AGraph {
   std::string get_formatted_string_using(const PrintMap& format_map) const;
 };
 } // namespace bingo
-#endif //INCLUDE_BINGOCPP_AGRAPH_H_
+#endif //BINGOCPP_INCLUDE_BINGOCPP_AGRAPH_H_

--- a/include/BingoCpp/agraph.h
+++ b/include/BingoCpp/agraph.h
@@ -41,15 +41,16 @@ namespace bingo {
 class AGraph {
  public:
   AGraph(
+      int genetic_age = 0,
+      double fitness = 1e9,
+      bool fit_set = false,
       Eigen::ArrayX3i command_array = Eigen::ArrayX3i(0, 3),
       Eigen::ArrayX3i short_command_array = Eigen::ArrayX3i(0, 3),
       Eigen::VectorXd constants = Eigen::VectorXd(0),
-      int num_constants = 0,
-      bool manual_constants = false,
       int needs_opt = false,
-      double fitness = 1e9,
-      bool fit_set = false,
-      int genetic_age = 0);
+      int num_constants = 0,
+      bool manual_constants = false
+      );
 
   AGraph(const AGraph& agraph);
 
@@ -271,16 +272,8 @@ class AGraph {
   // To string operator when passed into stream
   friend std::ostream& operator<<(std::ostream&, const AGraph&);
 
-  // Maps for operation nodes.
-  static const bool kIsArity2Map[13]; 
-  static const bool kIsTerminalMap[13];
-
   // Helper Functions
   void process_modified_command_array();
-  void renumber_constants(const std::vector<bool>& utilized_commands);
-  void update_short_command_array(const std::vector<bool>& utilized_commands);
-  std::string get_stack_string(const bool is_short=false) const;
-  std::string get_formatted_string_using(const PrintMap& format_map) const;
 };
 } // namespace bingo
 #endif //BINGOCPP_INCLUDE_BINGOCPP_AGRAPH_H_

--- a/include/BingoCpp/agraph.h
+++ b/include/BingoCpp/agraph.h
@@ -40,17 +40,7 @@ namespace bingo {
  */
 class AGraph {
  public:
-  AGraph(
-      int genetic_age = 0,
-      double fitness = 1e9,
-      bool fit_set = false,
-      Eigen::ArrayX3i command_array = Eigen::ArrayX3i(0, 3),
-      Eigen::ArrayX3i short_command_array = Eigen::ArrayX3i(0, 3),
-      Eigen::VectorXd constants = Eigen::VectorXd(0),
-      int needs_opt = false,
-      int num_constants = 0,
-      bool manual_constants = false
-      );
+  AGraph(bool manual_consants = false);
 
   AGraph(const AGraph& agraph);
 
@@ -102,6 +92,9 @@ class AGraph {
    * @return false otherwise
    */
   bool IsFitnessSet() const;
+
+
+  void SetFitnessStatus(bool val);
 
   /**
    * @brief Set the Genetic Age of this AGraph
@@ -264,7 +257,7 @@ class AGraph {
   Eigen::VectorXd constants_;
   bool needs_opt_;
   int num_constants_;
-  bool manual_constants_ = false;
+  bool manual_constants_;
   double fitness_;
   bool fit_set_;
   int genetic_age_;

--- a/include/BingoCpp/agraph_crossover.h
+++ b/include/BingoCpp/agraph_crossover.h
@@ -46,7 +46,7 @@ class AGraphCrossover {
    * @param parent_2 The second parent individual
    * @return CrossoverChildren The two children from the crossover
    */
-  CrossoverChildren crossover(AGraph& parent_1, AGraph& parent_2);
+  CrossoverChildren Crossover(AGraph& parent_1, AGraph& parent_2);
 
  private:
   std::mt19937 engine_;

--- a/include/BingoCpp/agraph_maps.h
+++ b/include/BingoCpp/agraph_maps.h
@@ -1,0 +1,99 @@
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace bingo {
+
+typedef std::unordered_map<int, std::string> PrintMap;
+typedef std::vector<std::vector<std::string>> PrintVector;
+
+const PrintMap kStackPrintMap {
+  {2, "({}) + ({})"},
+  {3, "({}) - ({})"},
+  {4, "({}) * ({})"},
+  {5, "({}) / ({}) "},
+  {6, "sin ({})"},
+  {7, "cos ({})"},
+  {8, "exp ({})"},
+  {9, "log ({})"},
+  {10, "({}) ^ ({})"},
+  {11, "abs ({})"},
+  {12, "sqrt ({})"},
+};
+
+const PrintMap kLatexPrintMap {
+  {2, "{} + {}"},
+  {3, "{} - ({})"},
+  {4, "({})({})"},
+  {5, "\\frac{ {} }{ {} }"},
+  {6, "sin{ {} }"},
+  {7, "cos{ {} }"},
+  {8, "exp{ {} }"},
+  {9, "log{ {} }"},
+  {10, "({})^{ ({}) }"},
+  {11, "|{}|"},
+  {12, "\\sqrt{ {} }"},
+};
+
+const PrintMap kConsolePrintMap {
+  {2, "{} + {}"},
+  {3, "{} - ({})"},
+  {4, "({})({})"},
+  {5, "({})/({})"},
+  {6, "sin({})"},
+  {7, "cos({})"},
+  {8, "exp({})"},
+  {9, "log({})"},
+  {10, "({})^({})"},
+  {11, "|{}|"},
+  {12, "sqrt({})"},
+};
+
+const bool kIsArity2Map[13] = {
+  false,
+  false,
+  true,
+  true,
+  true,
+  true,
+  false,
+  false,
+  false,
+  false,
+  true,
+  false,
+  false
+};
+
+const bool kIsTerminalMap[13] = {
+  true,
+  true,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false
+};
+
+const PrintVector kOperatorNames {
+  std::vector<std::string> {"load", "x"},
+  std::vector<std::string> {"constant", "c"},
+  std::vector<std::string> {"add", "addition", "+"},
+  std::vector<std::string> {"subtract", "subtraction", "-"},
+  std::vector<std::string> {"multiply", "multiplication", "*"},
+  std::vector<std::string> {"divide", "division", "/"},
+  std::vector<std::string> {"sine", "sin"},
+  std::vector<std::string> {"cosine", "cos"},
+  std::vector<std::string> {"exponential", "exp", "e"},
+  std::vector<std::string> {"logarithm", "log"},
+  std::vector<std::string> {"power", "pow", "^"},
+  std::vector<std::string> {"absolute value", "||", "|"},
+  std::vector<std::string> {"square root", "sqrt"}
+};
+} // namespace bingo

--- a/include/BingoCpp/backend.h
+++ b/include/BingoCpp/backend.h
@@ -38,7 +38,7 @@ namespace backend{
  * 
  * @return true 
  */
-inline bool isCpp() { return true; }
+inline bool IsCpp() { return true; }
 
 /**
  * @brief Evauluate the equation.
@@ -55,7 +55,7 @@ inline bool isCpp() { return true; }
  * 
  * @return Eigen::ArrayXXd The evaluation of the graph with x as the input data.
  */
-Eigen::ArrayXXd evaluate(const Eigen::ArrayX3i& stack,
+Eigen::ArrayXXd Evaluate(const Eigen::ArrayX3i& stack,
                          const Eigen::ArrayXXd& x,
                          const Eigen::VectorXd& constants);
 
@@ -77,7 +77,7 @@ Eigen::ArrayXXd evaluate(const Eigen::ArrayX3i& stack,
  * 
  * @return EvalAndDerivative Derivatives of all dimensions of x/constants at location x.
  */
-EvalAndDerivative evaluateWithDerivative(
+EvalAndDerivative EvaluateWithDerivative(
     const Eigen::ArrayX3i& stack,
     const Eigen::ArrayXXd& x,
     const Eigen::VectorXd& constants,
@@ -100,7 +100,7 @@ EvalAndDerivative evaluateWithDerivative(
  * 
  * @return Eigen::ArrayXXd The evaluation of the graph with x as the input data.
  */
-Eigen::ArrayXXd simplifyAndEvaluate(const Eigen::ArrayX3i& stack,
+Eigen::ArrayXXd SimplifyAndEvaluate(const Eigen::ArrayX3i& stack,
                                     const Eigen::ArrayXXd& x,
                                     const Eigen::VectorXd& constants);
 
@@ -123,7 +123,7 @@ Eigen::ArrayXXd simplifyAndEvaluate(const Eigen::ArrayX3i& stack,
  * 
  * @return EvalAndDerivative Derivatives of all dimensions of x/constants at location x.
  */
-EvalAndDerivative simplifyAndEvaluateWithDerivative(
+EvalAndDerivative SimplifyAndEvaluateWithDerivative(
     const Eigen::ArrayX3i& stack,
     const Eigen::ArrayXXd& x,
     const Eigen::VectorXd& constants,
@@ -139,7 +139,7 @@ EvalAndDerivative simplifyAndEvaluateWithDerivative(
  *
  * @return Simplified stack.
  */
-Eigen::ArrayX3i simplifyStack(const Eigen::ArrayX3i& stack);
+Eigen::ArrayX3i SimplifyStack(const Eigen::ArrayX3i& stack);
 
 /**
  * @brief Finds which commands are utilized in a stack.
@@ -151,7 +151,7 @@ Eigen::ArrayX3i simplifyStack(const Eigen::ArrayX3i& stack);
  *
  * @return vector describing which commands in the stack are used.
  */
-std::vector<bool> getUtilizedCommands(const Eigen::ArrayX3i& stack);
+std::vector<bool> GetUtilizedCommands(const Eigen::ArrayX3i& stack);
 } // namespace backend
 } // namespace bingo
 #endif

--- a/src/acyclic_graph.cpp
+++ b/src/acyclic_graph.cpp
@@ -177,18 +177,18 @@ int AcyclicGraph::count_constants() {
 // }
 
 Eigen::ArrayXXd AcyclicGraph::evaluate(Eigen::ArrayXXd &eval_x) {
-  return backend::evaluate(simple_stack, eval_x, constants);
+  return backend::Evaluate(simple_stack, eval_x, constants);
 }
 
 std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> AcyclicGraph::evaluate_deriv(
   Eigen::ArrayXXd &eval_x) {
-  return backend::evaluateWithDerivative(simple_stack, eval_x, constants);
+  return backend::EvaluateWithDerivative(simple_stack, eval_x, constants);
 }
 
 std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd>
 AcyclicGraph::evaluate_with_const_deriv(
   Eigen::ArrayXXd &eval_x) {
-  return backend::evaluateWithDerivative(simple_stack, eval_x, constants, false);
+  return backend::EvaluateWithDerivative(simple_stack, eval_x, constants, false);
 }
 
 

--- a/src/agraph.cpp
+++ b/src/agraph.cpp
@@ -54,7 +54,7 @@ AGraph::AGraph(bool manual_constants) {
   fit_set_ = false;
   genetic_age_ = 0;
 }
-    
+  
 AGraph::AGraph(const AGraph& agraph) {
   command_array_ = agraph.command_array_;
   short_command_array_ = agraph.short_command_array_;
@@ -72,6 +72,10 @@ AGraph AGraph::Copy() {
 }
 
 const Eigen::ArrayX3i& AGraph::GetCommandArray() const {
+  return command_array_;
+}
+
+Eigen::ArrayX3i& AGraph::GetCommandArrayModifiable() {
   return command_array_;
 }
 
@@ -128,7 +132,11 @@ void AGraph::SetLocalOptimizationParams(Eigen::VectorXd params) {
   needs_opt_ = false;
 }
 
-Eigen::VectorXd AGraph::GetLocalOptimizationParams() const {
+const Eigen::VectorXd& AGraph::GetLocalOptimizationParams() const {
+  return constants_;
+}
+
+Eigen::VectorXd& AGraph::GetLocalOptimizationParamsModifiable() {
   return constants_;
 }
 
@@ -223,7 +231,7 @@ void AGraph::ForceRenumberConstants() {
 }
 
 int AGraph::Distance(const AGraph& agraph) {
-  return (command_array_ != agraph.GetCommandArray()).sum();
+  return (command_array_ != agraph.GetCommandArray()).count();
 }
 
 bool AGraph::HasArityTwo(int node) {
@@ -288,7 +296,6 @@ std::string get_formatted_string_using(
   for (auto stack_element : short_command_array.rowwise()) {
     std::string temp_string = get_formatted_element_string(
         agraph, stack_element, string_list, format_map);
-    std::cout << temp_string << std::endl;
     string_list.push_back(temp_string);
   }
   return string_list.back();

--- a/src/agraph.cpp
+++ b/src/agraph.cpp
@@ -72,12 +72,12 @@ std::string print_string_with_args(const std::string& string,
 
 bool check_optimization_requirement(AGraph& agraph,
                                     const std::vector<bool>& utilized_commands) {
-  Eigen::ArrayX3i command_array = agraph.getCommandArray();
+  Eigen::ArrayX3i command_array = agraph.GetCommandArray();
   for (int i = 0; i < command_array.rows(); i++) {
     if (utilized_commands[i] && command_array(i, ArrayProps::kNodeIdx) == Op::LOAD_C) {
       if (command_array(i, ArrayProps::kOp1) == Op::C_OPTIMIZE ||
           command_array(i, ArrayProps::kOp1) >=
-          agraph.getLocalOptimizationParams().size()) {
+          agraph.GetLocalOptimizationParams().size()) {
         return true;
       }
     }
@@ -97,10 +97,10 @@ std::string get_stack_element_string(const AGraph& individual,
     temp_string += "X_" + std::to_string(param1);
   } else if (node == Op::LOAD_C) {
     if (param1 == Op::C_OPTIMIZE ||
-        param1 >= individual.getLocalOptimizationParams().size()) {
+        param1 >= individual.GetLocalOptimizationParams().size()) {
       temp_string += "C";
     } else {
-      Eigen::VectorXd parameter = individual.getLocalOptimizationParams();
+      Eigen::VectorXd parameter = individual.GetLocalOptimizationParams();
       temp_string += "C_" + std::to_string(param1) + " = " + 
                      std::to_string(parameter[param1]);
     }
@@ -128,10 +128,10 @@ std::string get_formatted_element_string(const AGraph& individual,
     temp_string = "X_" + std::to_string(param1);
   } else if (node == Op::LOAD_C) {
     if (param1 == Op::C_OPTIMIZE ||
-        param1 >= individual.getLocalOptimizationParams().size()) {
+        param1 >= individual.GetLocalOptimizationParams().size()) {
       temp_string = "?";
     } else {
-      Eigen::VectorXd parameter = individual.getLocalOptimizationParams();
+      Eigen::VectorXd parameter = individual.GetLocalOptimizationParams();
       temp_string = std::to_string(parameter[param1]);
     }
   } else {
@@ -155,39 +155,39 @@ AGraph::AGraph() {
 }
 
 AGraph::AGraph(const AGraph& agraph) {
-  this->setCommandArray(agraph.getCommandArray());
-  constants_ = agraph.getLocalOptimizationParams();
-  needs_opt_ = agraph.needsLocalOptimization();
-  num_constants_ = agraph.getNumberLocalOptimizationParams();
-  fitness_ = agraph.getFitness();
-  fit_set_ = agraph.isFitnessSet();
-  genetic_age_ = agraph.getGeneticAge();
+  this->SetCommandArray(agraph.GetCommandArray());
+  constants_ = agraph.GetLocalOptimizationParams();
+  needs_opt_ = agraph.NeedsLocalOptimization();
+  num_constants_ = agraph.GetNumberLocalOptimizationParams();
+  fitness_ = agraph.GetFitness();
+  fit_set_ = agraph.IsFitnessSet();
+  genetic_age_ = agraph.GetGeneticAge();
 }
 
-AGraph AGraph::copy() {
+AGraph AGraph::Copy() {
   AGraph return_val = AGraph(*this);
   return return_val;
 }
 
-Eigen::ArrayX3i AGraph::getCommandArray() const {
+Eigen::ArrayX3i AGraph::GetCommandArray() const {
   return command_array_;
 }
 
-void AGraph::setCommandArray(Eigen::ArrayX3i command_array) {
+void AGraph::SetCommandArray(Eigen::ArrayX3i command_array) {
   command_array_ = command_array;
   fitness_ = 1e9;
   fit_set_ = false;
   process_modified_command_array();
 }
 
-void AGraph::notifyCommandArrayModificiation() {
+void AGraph::NotifyCommandArrayModificiation() {
   fitness_ = 1e9;
   fit_set_ = false;
   process_modified_command_array();
 }
 
 void AGraph::process_modified_command_array() {
-  std::vector<bool> util = getUtilizedCommands();
+  std::vector<bool> util = GetUtilizedCommands();
 
   needs_opt_ = check_optimization_requirement(*this, util);
   if (needs_opt_)  {
@@ -237,52 +237,52 @@ void AGraph::update_short_command_array(const std::vector<bool>& utilized_comman
   }
 }
 
-double AGraph::getFitness() const {
+double AGraph::GetFitness() const {
   return fitness_;
 }
 
-void AGraph::setFitness(double fitness) {
+void AGraph::SetFitness(double fitness) {
   fitness_ = fitness;
   fit_set_ = true;
 }
 
-bool AGraph::isFitnessSet() const {
+bool AGraph::IsFitnessSet() const {
   return fit_set_;
 }
 
-void AGraph::setGeneticAge(const int age) {
+void AGraph::SetGeneticAge(const int age) {
   genetic_age_ = age;
 }
 
-int AGraph::getGeneticAge() const {
+int AGraph::GetGeneticAge() const {
   return genetic_age_;
 }
 
-std::vector<bool> AGraph::getUtilizedCommands() const {
-  return backend::getUtilizedCommands(command_array_);
+std::vector<bool> AGraph::GetUtilizedCommands() const {
+  return backend::GetUtilizedCommands(command_array_);
 }
 
-bool AGraph::needsLocalOptimization() const {
+bool AGraph::NeedsLocalOptimization() const {
   return needs_opt_;
 }
 
-int AGraph::getNumberLocalOptimizationParams() const {
+int AGraph::GetNumberLocalOptimizationParams() const {
   return num_constants_;
 }
 
-void AGraph::setLocalOptimizationParams(Eigen::VectorXd params) {
+void AGraph::SetLocalOptimizationParams(Eigen::VectorXd params) {
   constants_ = params;
   needs_opt_ = false;
 }
 
-Eigen::VectorXd AGraph::getLocalOptimizationParams() const {
+Eigen::VectorXd AGraph::GetLocalOptimizationParams() const {
   return constants_;
 }
 
-Eigen::ArrayXXd AGraph::evaluateEquationAt(Eigen::ArrayXXd& x) {
+Eigen::ArrayXXd AGraph::EvaluateEquationAt(Eigen::ArrayXXd& x) {
   Eigen::ArrayXXd f_of_x; 
   try {
-    f_of_x = backend::evaluate(this->command_array_,
+    f_of_x = backend::Evaluate(this->command_array_,
                                x,
                                this->constants_);
     return f_of_x;
@@ -293,10 +293,10 @@ Eigen::ArrayXXd AGraph::evaluateEquationAt(Eigen::ArrayXXd& x) {
   } 
 }
 
-EvalAndDerivative AGraph::evaluateEquationWithXGradientAt(Eigen::ArrayXXd& x) {
+EvalAndDerivative AGraph::EvaluateEquationWithXGradientAt(Eigen::ArrayXXd& x) {
   EvalAndDerivative df_dx;
   try {
-    df_dx = backend::evaluateWithDerivative(this->command_array_,
+    df_dx = backend::EvaluateWithDerivative(this->command_array_,
                                             x,
                                             this->constants_,
                                             true);
@@ -310,11 +310,11 @@ EvalAndDerivative AGraph::evaluateEquationWithXGradientAt(Eigen::ArrayXXd& x) {
   }
 }
 
-EvalAndDerivative AGraph::evaluateEquationWithLocalOptGradientAt(
+EvalAndDerivative AGraph::EvaluateEquationWithLocalOptGradientAt(
     Eigen::ArrayXXd& x) {
   EvalAndDerivative df_dc;
   try {
-    df_dc = backend::evaluateWithDerivative(this->command_array_,
+    df_dc = backend::EvaluateWithDerivative(this->command_array_,
                                             x,
                                             this->constants_,
                                             false);
@@ -329,14 +329,14 @@ EvalAndDerivative AGraph::evaluateEquationWithLocalOptGradientAt(
 }
 
 std::ostream& operator<<(std::ostream& strm, const AGraph& graph) {
-  return strm << graph.getConsoleString();
+  return strm << graph.GetConsoleString();
 }
 
-std::string AGraph::getLatexString() const {
+std::string AGraph::GetLatexString() const {
   return get_formatted_string_using(kLatexPrintMap);
 }
 
-std::string AGraph::getConsoleString() const {
+std::string AGraph::GetConsoleString() const {
   return get_formatted_string_using(kConsolePrintMap);
 }
 
@@ -350,7 +350,7 @@ std::string AGraph::get_formatted_string_using(const PrintMap& format_map) const
   return string_list.back();
 }
 
-std::string AGraph::getStackString() const {
+std::string AGraph::GetStackString() const {
   std::stringstream print_str; 
   print_str << "---full stack---\n"
             << get_stack_string()
@@ -373,18 +373,18 @@ std::string AGraph::get_stack_string(const bool is_short) const {
   return temp_string;
 }
 
-int AGraph::getComplexity() const {
-  std::vector<bool> commands = getUtilizedCommands();
+int AGraph::GetComplexity() const {
+  std::vector<bool> commands = GetUtilizedCommands();
   return std::count_if (commands.begin(), commands.end(), [](bool i) {
     return i;
   });
 }
 
-bool AGraph::hasArityTwo(int node) {
+bool AGraph::HasArityTwo(int node) {
   return kIsArity2Map[node];
 }
 
-bool AGraph::isTerminal(int node) {
+bool AGraph::IsTerminal(int node) {
   return kIsTerminalMap[node];
 }
 

--- a/src/agraph.cpp
+++ b/src/agraph.cpp
@@ -43,35 +43,28 @@ std::string get_stack_element_string(const AGraph& individual,
                                      const Eigen::ArrayX3i& stack_element);
 } // namespace
 
-AGraph::AGraph(
-    int genetic_age,
-    double fitness,
-    bool fit_set,
-    Eigen::ArrayX3i command_array,
-    Eigen::ArrayX3i short_command_array,
-    Eigen::VectorXd constants,
-    int needs_opt,
-    int num_constants,
-    bool manual_constants) {
-  command_array_ = command_array;
-  short_command_array_ = short_command_array;
-  constants_ = constants;
-  num_constants_ = num_constants;
+AGraph::AGraph(bool manual_constants) {
+  command_array_ = Eigen::ArrayX3i(0, 3);
+  short_command_array_ = Eigen::ArrayX3i(0, 3);
+  constants_ = Eigen::VectorXd(0);
+  needs_opt_ = false;
+  num_constants_ = 0;
   manual_constants_ = manual_constants;
-  needs_opt_ = needs_opt;
-  fitness_ = fitness;
-  fit_set_ = fit_set;
-  genetic_age_ = genetic_age;
+  fitness_ = kFitnessNotSet;
+  fit_set_ = false;
+  genetic_age_ = 0;
 }
-
+    
 AGraph::AGraph(const AGraph& agraph) {
-  this->SetCommandArray(agraph.GetCommandArray());
-  constants_ = agraph.GetLocalOptimizationParams();
-  needs_opt_ = agraph.NeedsLocalOptimization();
-  num_constants_ = agraph.GetNumberLocalOptimizationParams();
-  fitness_ = agraph.GetFitness();
-  fit_set_ = agraph.IsFitnessSet();
-  genetic_age_ = agraph.GetGeneticAge();
+  command_array_ = agraph.command_array_;
+  short_command_array_ = agraph.short_command_array_;
+  constants_ = agraph.constants_;
+  needs_opt_ = agraph.needs_opt_;
+  num_constants_ = agraph.num_constants_;
+  manual_constants_ = agraph.manual_constants_;
+  fitness_ = agraph.fitness_;
+  fit_set_ = agraph.fit_set_;
+  genetic_age_ = agraph.genetic_age_;
 }
 
 AGraph AGraph::Copy() {
@@ -104,6 +97,10 @@ void AGraph::SetFitness(double fitness) {
 
 bool AGraph::IsFitnessSet() const {
   return fit_set_;
+}
+
+void AGraph::SetFitnessStatus(bool val) {
+  fit_set_ = val;
 }
 
 void AGraph::SetGeneticAge(const int age) {

--- a/src/agraph.cpp
+++ b/src/agraph.cpp
@@ -50,6 +50,22 @@ const PrintMap kConsolePrintMap {
   {12, "sqrt({})"},
 };
 
+const PrintVector kOperatorNames {
+  std::vector<std::string> {"load", "x"},
+  std::vector<std::string> {"constant", "c"},
+  std::vector<std::string> {"add", "addition", "+"},
+  std::vector<std::string> {"subtract", "subtraction", "-"},
+  std::vector<std::string> {"multiply", "multiplication", "*"},
+  std::vector<std::string> {"divide", "division", "/"},
+  std::vector<std::string> {"sine", "sin"},
+  std::vector<std::string> {"cosine", "cos"},
+  std::vector<std::string> {"exponential", "exp", "e"},
+  std::vector<std::string> {"logarithm", "log"},
+  std::vector<std::string> {"power", "pow", "^"},
+  std::vector<std::string> {"absolute value", "||", "|"},
+  std::vector<std::string> {"square root", "sqrt"}
+};
+
 namespace bingo {
 namespace {
 
@@ -143,15 +159,25 @@ std::string get_formatted_element_string(const AGraph& individual,
 }
 } // namespace
 
-AGraph::AGraph() {
-  command_array_ = Eigen::ArrayX3i(0, 3);
-  short_command_array_ = Eigen::ArrayX3i(0, 3);
-  constants_ = Eigen::VectorXd(0);
-  num_constants_ = 0;
-  needs_opt_ = false;
-  fitness_ = 1e9;
-  fit_set_ = false;
-  genetic_age_ = 0;
+AGraph::AGraph(
+    Eigen::ArrayX3i command_array,
+    Eigen::ArrayX3i short_command_array,
+    Eigen::VectorXd constants,
+    int num_constants,
+    bool manual_constants,
+    int needs_opt,
+    double fitness,
+    bool fit_set,
+    int genetic_age) {
+  command_array_ = command_array;
+  short_command_array_ = short_command_array;
+  constants_ = constants;
+  num_constants_ = num_constants;
+  manual_constants_ = manual_constants;
+  needs_opt_ = needs_opt;
+  fitness_ = fitness;
+  fit_set_ = fit_set;
+  genetic_age_ = genetic_age;
 }
 
 AGraph::AGraph(const AGraph& agraph) {
@@ -293,7 +319,8 @@ Eigen::ArrayXXd AGraph::EvaluateEquationAt(Eigen::ArrayXXd& x) {
   } 
 }
 
-EvalAndDerivative AGraph::EvaluateEquationWithXGradientAt(Eigen::ArrayXXd& x) {
+EvalAndDerivative
+AGraph::EvaluateEquationWithXGradientAt(Eigen::ArrayXXd& x) {
   EvalAndDerivative df_dx;
   try {
     df_dx = backend::EvaluateWithDerivative(this->command_array_,
@@ -310,8 +337,8 @@ EvalAndDerivative AGraph::EvaluateEquationWithXGradientAt(Eigen::ArrayXXd& x) {
   }
 }
 
-EvalAndDerivative AGraph::EvaluateEquationWithLocalOptGradientAt(
-    Eigen::ArrayXXd& x) {
+EvalAndDerivative
+AGraph::EvaluateEquationWithLocalOptGradientAt(Eigen::ArrayXXd& x) {
   EvalAndDerivative df_dc;
   try {
     df_dc = backend::EvaluateWithDerivative(this->command_array_,
@@ -378,6 +405,25 @@ int AGraph::GetComplexity() const {
   return std::count_if (commands.begin(), commands.end(), [](bool i) {
     return i;
   });
+}
+
+void AGraph::ForceRenumberConstants() {
+  std::vector<bool> util_commands = GetUtilizedCommands();
+  renumber_constants(util_commands);
+}
+
+int AGraph::Distance(const AGraph& agraph) {
+  std::vector<bool> similar_operations(std::max(command_array_.rows(),
+                                       agraph.GetCommandArray().rows()));
+  for (int i = 0; i < command_array_.rows(); i ++) {
+    // if (!valid_index(i, agraph.GetCommandArray())) {
+    //   std::fill(similar_operations, std::begin(similar_operations) + i,
+    //                                 std::end(similar_operations));
+    // } else {
+    //   bool val = (command_array_.row(i) == agraph.GetCommandArray().row(i));
+    // }
+    std::cout << (command_array_.row(0) == agraph.GetCommandArray().row(0)) << std::endl;
+  }
 }
 
 bool AGraph::HasArityTwo(int node) {

--- a/src/agraph_crossover.cpp
+++ b/src/agraph_crossover.cpp
@@ -15,15 +15,15 @@ int find_random_int(std::mt19937& engine, int min, int max) {
 }
 
 void perform_crossover(AGraph& child, AGraph& parent, int cross_point) {
-  Eigen::ArrayX3i child_array = child.getCommandArray();
-  Eigen::ArrayX3i parent_array = parent.getCommandArray();
+  Eigen::ArrayX3i child_array = child.GetCommandArray();
+  Eigen::ArrayX3i parent_array = parent.GetCommandArray();
   int num_modified_rows = parent_array.rows() - cross_point;
 
   // Hard coded substitute 2 for row length
   child_array.block(cross_point, 0, num_modified_rows, child_array.cols()) =
     parent_array.block(cross_point, 0, num_modified_rows, parent_array.cols());
   
-  child.setCommandArray(child_array);
+  child.SetCommandArray(child_array);
 }
 } // namespace
 
@@ -40,19 +40,19 @@ AGraphCrossover::AGraphCrossover(const AGraphCrossover& agc) {
   engine_ = agc.engine_;
 }
 
-CrossoverChildren AGraphCrossover::crossover(AGraph& parent_1,
+CrossoverChildren AGraphCrossover::Crossover(AGraph& parent_1,
                                              AGraph& parent_2) {
-  AGraph child_1 = parent_1.copy();
-  AGraph child_2 = parent_2.copy();
+  AGraph child_1 = parent_1.Copy();
+  AGraph child_2 = parent_2.Copy();
 
-  size_t agraph_size = parent_1.getCommandArray().rows();
+  size_t agraph_size = parent_1.GetCommandArray().rows();
   int cross_point = find_random_int(engine_, 1, agraph_size - 1);
   perform_crossover(child_1, parent_2, cross_point);
   perform_crossover(child_2, parent_1, cross_point);
 
-  int child_age = std::max(parent_1.getGeneticAge(), parent_2.getGeneticAge());
-  child_1.setGeneticAge(child_age);
-  child_2.setGeneticAge(child_age);
+  int child_age = std::max(parent_1.GetGeneticAge(), parent_2.GetGeneticAge());
+  child_1.SetGeneticAge(child_age);
+  child_2.SetGeneticAge(child_age);
 
   return std::make_pair(child_1, child_2);
 }

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -155,7 +155,7 @@ EvalAndDerivative evaluate_with_derivative_and_mask(
 }
 } // namespace
 
-Eigen::ArrayXXd evaluate(const Eigen::ArrayX3i& stack,
+Eigen::ArrayXXd Evaluate(const Eigen::ArrayX3i& stack,
                          const Eigen::ArrayXXd& x,
                          const Eigen::VectorXd& constants) {
   std::vector<Eigen::ArrayXXd> _forward_eval = forward_eval(
@@ -163,7 +163,7 @@ Eigen::ArrayXXd evaluate(const Eigen::ArrayX3i& stack,
   return _forward_eval.back();  
 }
 
-std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> evaluateWithDerivative(
+std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> EvaluateWithDerivative(
     const Eigen::ArrayX3i& stack,
     const Eigen::ArrayXXd& x,
     const Eigen::VectorXd& constants,
@@ -172,25 +172,25 @@ std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> evaluateWithDerivative(
     stack, x, constants, param_x_or_c);
 }
 
-Eigen::ArrayXXd simplifyAndEvaluate(const Eigen::ArrayX3i& stack,
+Eigen::ArrayXXd SimplifyAndEvaluate(const Eigen::ArrayX3i& stack,
                                     const Eigen::ArrayXXd& x,
                                     const Eigen::VectorXd& constants) {
-  std::vector<bool> mask = getUtilizedCommands(stack);
+  std::vector<bool> mask = GetUtilizedCommands(stack);
   std::vector<Eigen::ArrayXXd> forward_eval = forward_eval_with_mask(
       stack, x, constants, mask);
   return forward_eval.back();
 }
 
-EvalAndDerivative simplifyAndEvaluateWithDerivative(
+EvalAndDerivative SimplifyAndEvaluateWithDerivative(
     const Eigen::ArrayX3i& stack,
     const Eigen::ArrayXXd& x,
     const Eigen::VectorXd& constants,
     const bool param_x_or_c) {
-  std::vector<bool> mask = getUtilizedCommands(stack);
+  std::vector<bool> mask = GetUtilizedCommands(stack);
   return evaluate_with_derivative_and_mask(stack, x, constants, mask, param_x_or_c);
 }
 
-std::vector<bool> getUtilizedCommands(const Eigen::ArrayX3i& stack) {
+std::vector<bool> GetUtilizedCommands(const Eigen::ArrayX3i& stack) {
   std::vector<bool> used_commands(stack.rows());
   used_commands.back() = true;
   int stack_size = stack.rows();
@@ -201,7 +201,7 @@ std::vector<bool> getUtilizedCommands(const Eigen::ArrayX3i& stack) {
     int param2 = stack(row, ArrayProps::kOp2);
     if (used_commands[row] && node > Op::LOAD_C) {
       used_commands[param1] = true;
-      if (AGraph::hasArityTwo(node)) {
+      if (AGraph::HasArityTwo(node)) {
         used_commands[param2] = true;
       }
     }
@@ -209,8 +209,8 @@ std::vector<bool> getUtilizedCommands(const Eigen::ArrayX3i& stack) {
   return used_commands;
 }
 
-Eigen::ArrayX3i simplifyStack(const Eigen::ArrayX3i& stack) {
-  std::vector<bool> used_command = getUtilizedCommands(stack);
+Eigen::ArrayX3i SimplifyStack(const Eigen::ArrayX3i& stack) {
+  std::vector<bool> used_command = GetUtilizedCommands(stack);
   std::map<int, int> reduced_param_map;
   int num_commands = 0;
   num_commands = std::accumulate(used_command.begin(), used_command.end(), 0);
@@ -219,12 +219,12 @@ Eigen::ArrayX3i simplifyStack(const Eigen::ArrayX3i& stack) {
   for (int i = 0, j = 0; i < stack.rows(); ++i) {
     if (used_command[i]) {
       new_stack(j, ArrayProps::kNodeIdx) = stack(i, ArrayProps::kNodeIdx);
-      if (AGraph::isTerminal(new_stack(j, ArrayProps::kNodeIdx))) {
+      if (AGraph::IsTerminal(new_stack(j, ArrayProps::kNodeIdx))) {
         new_stack(j, ArrayProps::kOp1) = stack(i, ArrayProps::kOp1);
         new_stack(j, ArrayProps::kOp2) = stack(i, ArrayProps::kOp2);
       } else {
         new_stack(j, ArrayProps::kOp1) = reduced_param_map[stack(i, ArrayProps::kOp1)];
-        if (AGraph::hasArityTwo(new_stack(j, ArrayProps::kNodeIdx))) {
+        if (AGraph::HasArityTwo(new_stack(j, ArrayProps::kNodeIdx))) {
           new_stack(j, ArrayProps::kOp2) = reduced_param_map[stack(i, ArrayProps::kOp2)];
         } else {
           new_stack(j, ArrayProps::kOp2) = new_stack(j, ArrayProps::kOp2);

--- a/tests/agraph_backend_tests.cpp
+++ b/tests/agraph_backend_tests.cpp
@@ -155,7 +155,7 @@ TEST_P(AGraphBackend, simplify_and_evaluate) {
   stack << 0, 0, 0,
            0, 1, 0,
            operator_i, 0, 0;
-  Eigen::ArrayXXd f_of_x = simplifyAndEvaluate(stack,
+  Eigen::ArrayXXd f_of_x = SimplifyAndEvaluate(stack,
                                                sample_agraph_1_values.x_vals,
                                                sample_agraph_1_values.constants);
   ASSERT_TRUE(testutils::almost_equal(expected_outcome, f_of_x));
@@ -176,7 +176,7 @@ TEST_P(AGraphBackend, simplify_and_evaluate_x_deriv) {
   Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
   Eigen::ArrayXXd constants = sample_agraph_1_values.constants;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> res_and_gradient = 
-    simplifyAndEvaluateWithDerivative(stack,
+    SimplifyAndEvaluateWithDerivative(stack,
                                       x_0,
                                       constants,
                                       true);
@@ -202,7 +202,7 @@ TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {
   Eigen::ArrayXXd x_0 = sample_agraph_1_values.x_vals;
   Eigen::ArrayXXd constants = sample_agraph_1_values.constants;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> res_and_gradient = 
-    simplifyAndEvaluateWithDerivative(stack,
+    SimplifyAndEvaluateWithDerivative(stack,
                                       x_0,
                                       constants,
                                       false);
@@ -212,7 +212,7 @@ TEST_P(AGraphBackend, simplify_and_evaluate_c_deriv) {
 INSTANTIATE_TEST_CASE_P(,AGraphBackend, ::testing::Range(0, N_OPS, 1));
 
 TEST_F(AGraphBackend, evaluate) {
-  Eigen::ArrayXXd y = evaluate(simple_stack, x, constants);
+  Eigen::ArrayXXd y = Evaluate(simple_stack, x, constants);
   Eigen::ArrayXXd y_true = x.col(0) * (constants[0] + constants[1] 
                           / x.col(1)) - x.col(0);
   ASSERT_TRUE(testutils::almost_equal(y, y_true));
@@ -220,7 +220,7 @@ TEST_F(AGraphBackend, evaluate) {
 
 TEST_F(AGraphBackend, evaluate_and_derivative) {
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> y_and_dy =
-    evaluateWithDerivative(simple_stack, x, constants);
+    EvaluateWithDerivative(simple_stack, x, constants);
   Eigen::ArrayXXd y_true = x.col(0) * (constants[0] + constants[1] 
                           / x.col(1)) - x.col(0);
   Eigen::ArrayXXd dy_true = Eigen::ArrayXXd::Zero(3, 3);
@@ -232,22 +232,22 @@ TEST_F(AGraphBackend, evaluate_and_derivative) {
 }
 
 TEST_F(AGraphBackend, mask_evaluate) {
-  Eigen::ArrayXXd y = evaluate(simple_stack, x, constants);
-  Eigen::ArrayXXd y_simple = simplifyAndEvaluate(simple_stack, x, constants);
+  Eigen::ArrayXXd y = Evaluate(simple_stack, x, constants);
+  Eigen::ArrayXXd y_simple = SimplifyAndEvaluate(simple_stack, x, constants);
   ASSERT_TRUE(testutils::almost_equal(y, y_simple));
 }
 
 TEST_F(AGraphBackend, mask_evaluate_and_derivative) {
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> y_and_dy =
-    evaluateWithDerivative(simple_stack, x, constants);
+    EvaluateWithDerivative(simple_stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> y_and_dy_simple =
-    simplifyAndEvaluateWithDerivative(simple_stack, x, constants);
+    SimplifyAndEvaluateWithDerivative(simple_stack, x, constants);
   ASSERT_TRUE(testutils::almost_equal(y_and_dy.first, y_and_dy_simple.first));
   ASSERT_TRUE(testutils::almost_equal(y_and_dy.first, y_and_dy_simple.first));
 }
 
 TEST_F(AGraphBackend, get_utilized_commands) {
-  std::vector<bool> used_commands = getUtilizedCommands(simple_stack);
+  std::vector<bool> used_commands = GetUtilizedCommands(simple_stack);
   int num_used_commands = 0;
   for (auto const& command_is_used : used_commands) {
     if (command_is_used) {

--- a/tests/agraph_crossover_tests.cpp
+++ b/tests/agraph_crossover_tests.cpp
@@ -25,14 +25,14 @@ class AGraphCrossoverTest : public ::testing::Test {
 
 TEST_F(AGraphCrossoverTest, test_single_point_crossover) {
   AGraphCrossover crossover;
-  CrossoverChildren children = crossover.crossover(sample_agraph_1, sample_agraph_2);
+  CrossoverChildren children = crossover.Crossover(sample_agraph_1, sample_agraph_2);
 
   bool found_crossover_point = false;
-  for (size_t i = 0; i < sample_agraph_1.getCommandArray().rows(); i ++) {
-    Eigen::ArrayX3i parent_1_op = sample_agraph_1.getCommandArray().row(i);
-    Eigen::ArrayX3i parent_2_op = sample_agraph_2.getCommandArray().row(i);
-    Eigen::ArrayX3i child_1_op = children.first.getCommandArray().row(i); 
-    Eigen::ArrayX3i child_2_op = children.second.getCommandArray().row(i); 
+  for (size_t i = 0; i < sample_agraph_1.GetCommandArray().rows(); i ++) {
+    Eigen::ArrayX3i parent_1_op = sample_agraph_1.GetCommandArray().row(i);
+    Eigen::ArrayX3i parent_2_op = sample_agraph_2.GetCommandArray().row(i);
+    Eigen::ArrayX3i child_1_op = children.first.GetCommandArray().row(i); 
+    Eigen::ArrayX3i child_2_op = children.second.GetCommandArray().row(i); 
     if (!found_crossover_point) {
       if (parent_1_op.isApprox(child_1_op)) {
         ASSERT_TRUE(parent_2_op.isApprox(child_2_op));
@@ -52,25 +52,25 @@ TEST_F(AGraphCrossoverTest, test_single_point_crossover) {
 
 TEST_F(AGraphCrossoverTest, modified_genetic_age) {
   AGraphCrossover crossover;
-  CrossoverChildren children = crossover.crossover(sample_agraph_1,
+  CrossoverChildren children = crossover.Crossover(sample_agraph_1,
                                                    sample_agraph_2);
 
-  int oldest_parent_age = std::max(sample_agraph_1.getGeneticAge(),
-                                   sample_agraph_2.getGeneticAge());
-  ASSERT_TRUE(children.first.getGeneticAge() == oldest_parent_age);
-  ASSERT_TRUE(children.second.getGeneticAge() == oldest_parent_age);
+  int oldest_parent_age = std::max(sample_agraph_1.GetGeneticAge(),
+                                   sample_agraph_2.GetGeneticAge());
+  ASSERT_TRUE(children.first.GetGeneticAge() == oldest_parent_age);
+  ASSERT_TRUE(children.second.GetGeneticAge() == oldest_parent_age);
 }
 
 TEST_F(AGraphCrossoverTest, crossover_resets_fitness) {
-  ASSERT_TRUE(sample_agraph_1.isFitnessSet());
-  ASSERT_TRUE(sample_agraph_2.isFitnessSet());
+  ASSERT_TRUE(sample_agraph_1.IsFitnessSet());
+  ASSERT_TRUE(sample_agraph_2.IsFitnessSet());
 
   AGraphCrossover crossover;
-  CrossoverChildren children = crossover.crossover(sample_agraph_1,
+  CrossoverChildren children = crossover.Crossover(sample_agraph_1,
                                                    sample_agraph_2);
-  ASSERT_FALSE(children.first.isFitnessSet());
-  ASSERT_FALSE(children.second.isFitnessSet());
-  ASSERT_DOUBLE_EQ(children.first.getFitness(), 1e9);
-  ASSERT_DOUBLE_EQ(children.second.getFitness(), 1e9);
+  ASSERT_FALSE(children.first.IsFitnessSet());
+  ASSERT_FALSE(children.second.IsFitnessSet());
+  ASSERT_DOUBLE_EQ(children.first.GetFitness(), 1e9);
+  ASSERT_DOUBLE_EQ(children.second.GetFitness(), 1e9);
 }
 }

--- a/tests/agraph_nodes_tests.cpp
+++ b/tests/agraph_nodes_tests.cpp
@@ -48,7 +48,7 @@ TEST(AGraphNodesTest, XLoad) {
   x << 7., 6., 9., 5., 11., 4., 3., 2., 1.;
   Eigen::ArrayXXd a_true(3, 1);
   a_true << 6., 11., 2.;
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -63,7 +63,7 @@ TEST(AGraphNodesTest, CLoad) {
   constants << 3.0, 5.0;
   Eigen::ArrayXXd a_true(3, 1);
   a_true << 5., 5., 5.;
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -95,20 +95,20 @@ TEST(AGraphNodesTest, Addition) {
   a_true_xx << 14., 12., 18.;
   Eigen::ArrayXXd a_true_cc(3, 1);
   a_true_cc << 6., 6., 6.;
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
-  Eigen::ArrayXXd test3 = evaluate(stack3, x, constants);
-  Eigen::ArrayXXd test4 = evaluate(stack4, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test3 = Evaluate(stack3, x, constants);
+  Eigen::ArrayXXd test4 = Evaluate(stack4, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << 1., 0., 0., 1., 0., 0., 1., 0., 0.;
   Eigen::ArrayXXd d_true_xx(3, 3);
   d_true_xx << 2., 0., 0., 2., 0., 0., 2., 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_xc =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_cx =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_xx =
-    evaluateWithDerivative(stack3, x, constants);
+    EvaluateWithDerivative(stack3, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -153,10 +153,10 @@ TEST(AGraphNodesTest, Subtraction) {
   a_true2 << -4., -3., -6.;
   Eigen::ArrayXXd a_true_xx(3, 1);
   a_true_xx << 0., 0., 0.;
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
-  Eigen::ArrayXXd test3 = evaluate(stack3, x, constants);
-  Eigen::ArrayXXd test4 = evaluate(stack4, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test3 = Evaluate(stack3, x, constants);
+  Eigen::ArrayXXd test4 = Evaluate(stack4, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << 1., 0., 0., 1., 0., 0., 1., 0., 0.;
   Eigen::ArrayXXd d_true2(3, 3);
@@ -164,11 +164,11 @@ TEST(AGraphNodesTest, Subtraction) {
   Eigen::ArrayXXd d_true_xx(3, 3);
   d_true_xx << 0., 0., 0., 0., 0., 0., 0., 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_xc =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_cx =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_xx =
-    evaluateWithDerivative(stack3, x, constants);
+    EvaluateWithDerivative(stack3, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -212,20 +212,20 @@ TEST(AGraphNodesTest, Multiplication) {
   a_true_xx << (7. * 7.), (6. * 6.), (9.* 9.);
   Eigen::ArrayXXd a_true_cc(3, 1);
   a_true_cc << 9., 9., 9.;
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
-  Eigen::ArrayXXd test3 = evaluate(stack3, x, constants);
-  Eigen::ArrayXXd test4 = evaluate(stack4, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test3 = Evaluate(stack3, x, constants);
+  Eigen::ArrayXXd test4 = Evaluate(stack4, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << 3., 0., 0., 3., 0., 0., 3., 0., 0.;
   Eigen::ArrayXXd d_true_xx(3, 3);
   d_true_xx << 14., 0., 0., 12., 0., 0., 18., 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_xc =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_cx =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_xx =
-    evaluateWithDerivative(stack3, x, constants);
+    EvaluateWithDerivative(stack3, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -271,10 +271,10 @@ TEST(AGraphNodesTest, Division) {
   a_true_xx << 1., 1., 1.;
   Eigen::ArrayXXd a_true_cc(3, 1);
   a_true_cc << 1., 1., 1.;
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
-  Eigen::ArrayXXd test3 = evaluate(stack3, x, constants);
-  Eigen::ArrayXXd test4 = evaluate(stack4, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test3 = Evaluate(stack3, x, constants);
+  Eigen::ArrayXXd test4 = Evaluate(stack4, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << (1. / 3.), 0., 0., (1. / 3.), 0., 0., (1. / 3.), 0., 0.;
   Eigen::ArrayXXd d_true2(3, 3);
@@ -284,11 +284,11 @@ TEST(AGraphNodesTest, Division) {
   Eigen::ArrayXXd d_true_xx(3, 3);
   d_true_xx << 0., 0., 0., 0., 0., 0., 0., 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_xc =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_cx =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_xx =
-    evaluateWithDerivative(stack3, x, constants);
+    EvaluateWithDerivative(stack3, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -322,8 +322,8 @@ TEST(AGraphNodesTest, Sin) {
   a_true << (sin(3.)), (sin(3.)), (sin(3.));
   Eigen::ArrayXXd a_true_x(3, 1);
   a_true_x << (sin(7.)), (sin(6.)), (sin(9.));
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << 0., 0., 0., 0., 0., 0., 0., 0., 0.;
   Eigen::ArrayXXd d_true_x(3, 3);
@@ -331,9 +331,9 @@ TEST(AGraphNodesTest, Sin) {
            (cos(6.)), 0., 0.,
            (cos(9.)), 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_c =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_x =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -363,8 +363,8 @@ TEST(AGraphNodesTest, Cos) {
   a_true << (cos(3.)), (cos(3.)), (cos(3.));
   Eigen::ArrayXXd a_true_x(3, 1);
   a_true_x << (cos(7.)), (cos(6.)), (cos(9.));
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << 0., 0., 0., 0., 0., 0., 0., 0., 0.;
   Eigen::ArrayXXd d_true_x(3, 3);
@@ -372,9 +372,9 @@ TEST(AGraphNodesTest, Cos) {
            (-sin(6.)), 0., 0.,
            (-sin(9.)), 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_c =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_x =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -404,8 +404,8 @@ TEST(AGraphNodesTest, Exp) {
   a_true << (exp(3.)), (exp(3.)), (exp(3.));
   Eigen::ArrayXXd a_true_x(3, 1);
   a_true_x << (exp(7.)), (exp(6.)), (exp(9.));
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << 0., 0., 0., 0., 0., 0., 0., 0., 0.;
   Eigen::ArrayXXd d_true_x(3, 3);
@@ -413,9 +413,9 @@ TEST(AGraphNodesTest, Exp) {
            (exp(6.)), 0., 0.,
            (exp(9.)), 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_c =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_x =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -445,8 +445,8 @@ TEST(AGraphNodesTest, Log) {
   a_true << (log(abs(3.))), (log(abs(3.))), (log(abs(3.)));
   Eigen::ArrayXXd a_true_x(3, 1);
   a_true_x << (log(abs(7.))), (log(abs(6.))), (log(abs(9.)));
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << 0., 0., 0., 0., 0., 0., 0., 0., 0.;
   Eigen::ArrayXXd d_true_x(3, 3);
@@ -454,9 +454,9 @@ TEST(AGraphNodesTest, Log) {
            (1. / abs(6.)), 0., 0.,
            (1. / abs(9.)), 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_c =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_x =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -498,10 +498,10 @@ TEST(AGraphNodesTest, Power) {
   a_true_xx << (pow(7., 7.)), (pow(6., 6.)), (pow(9., 9.));
   Eigen::ArrayXXd a_true_cc(3, 1);
   a_true_cc << (pow(3., 3.)), (pow(3., 3.)), (pow(3., 3.));
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
-  Eigen::ArrayXXd test3 = evaluate(stack3, x, constants);
-  Eigen::ArrayXXd test4 = evaluate(stack4, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test3 = Evaluate(stack3, x, constants);
+  Eigen::ArrayXXd test4 = Evaluate(stack4, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << (3. * pow(7., 2.)), 0., 0.,
          (3. * pow(6., 2.)), 0., 0.,
@@ -515,11 +515,11 @@ TEST(AGraphNodesTest, Power) {
             (pow(6., 6.) * (1 + log(6.))), 0., 0.,
             (pow(9., 9.) * (1 + log(9.))), 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_xc =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_cx =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_xx =
-    evaluateWithDerivative(stack3, x, constants);
+    EvaluateWithDerivative(stack3, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -553,16 +553,16 @@ TEST(AGraphNodesTest, Absolute) {
   a_true << 3., 3., 3.;
   Eigen::ArrayXXd a_true_x(3, 1);
   a_true_x << 7., 6., 9.;
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << 0., 0., 0., 0., 0., 0., 0., 0., 0.;
   Eigen::ArrayXXd d_true_x(3, 3);
   d_true_x << -1., 0., 0., 1., 0., 0., -1., 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_c =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_x =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));
@@ -592,8 +592,8 @@ TEST(AGraphNodesTest, Sqrt) {
   a_true << (sqrt(abs(3.))), (sqrt(abs(3.))), (sqrt(abs(3.)));
   Eigen::ArrayXXd a_true_x(3, 1);
   a_true_x << (sqrt(abs(-7.))), (sqrt(abs(6.))), (sqrt(abs(-9.)));
-  Eigen::ArrayXXd test = evaluate(stack, x, constants);
-  Eigen::ArrayXXd test2 = evaluate(stack2, x, constants);
+  Eigen::ArrayXXd test = Evaluate(stack, x, constants);
+  Eigen::ArrayXXd test2 = Evaluate(stack2, x, constants);
   Eigen::ArrayXXd d_true(3, 3);
   d_true << 0., 0., 0., 0., 0., 0., 0., 0., 0.;
   Eigen::ArrayXXd d_true_x(3, 3);
@@ -601,9 +601,9 @@ TEST(AGraphNodesTest, Sqrt) {
            1. / (2.*sqrt(6.)), 0., 0.,
            -1. / (2.*sqrt(9.)), 0., 0.;
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_c =
-    evaluateWithDerivative(stack, x, constants);
+    EvaluateWithDerivative(stack, x, constants);
   std::pair<Eigen::ArrayXXd, Eigen::ArrayXXd> d_x =
-    evaluateWithDerivative(stack2, x, constants);
+    EvaluateWithDerivative(stack2, x, constants);
 
   for (size_t i = 0; i < x.rows(); ++i) {
     ASSERT_DOUBLE_EQ(test(i), a_true(i));

--- a/tests/agraph_tests.cpp
+++ b/tests/agraph_tests.cpp
@@ -270,6 +270,10 @@ TEST_F(AGraphTest, setting_command_array_unsets_fitness) {
 
 TEST_F(AGraphTest, TestDistanceBetweenGraphs) {
   ASSERT_EQ(sample_agraph_1.Distance(sample_agraph_1), 0);
+  AGraph other_agraph = sample_agraph_1.Copy();
+  other_agraph.GetCommandArrayModifiable().row(2) << 6, 1, 0;
+  ASSERT_EQ(sample_agraph_1.Distance(other_agraph), 3);
+
 }
 
 // class AGraphExceptionTest : public ::testing::Test {

--- a/tests/agraph_tests.cpp
+++ b/tests/agraph_tests.cpp
@@ -270,7 +270,6 @@ TEST_F(AGraphTest, setting_command_array_unsets_fitness) {
 
 TEST_F(AGraphTest, TestDistanceBetweenGraphs) {
   ASSERT_EQ(sample_agraph_1.Distance(sample_agraph_1), 0);
-  sample_agraph_1.Distance(all_funcs_graph);
 }
 
 // class AGraphExceptionTest : public ::testing::Test {

--- a/tests/agraph_tests.cpp
+++ b/tests/agraph_tests.cpp
@@ -230,7 +230,7 @@ TEST_F(AGraphTest, evaluatWithCDerivative) {
   ASSERT_TRUE(testutils::almost_equal(sample_agraph_1_values.grad_c, df_dc));
 }
 
-TEST_F(AGraphTest, get_number_of_optimization_params) {
+TEST_F(AGraphTest, NeedsLocalOptimization) {
   ASSERT_TRUE(invalid_graph.NeedsLocalOptimization());
 }
 
@@ -266,6 +266,11 @@ TEST_F(AGraphTest, setting_command_array_unsets_fitness) {
   ASSERT_TRUE(sample_agraph_1.IsFitnessSet());
   sample_agraph_1.SetCommandArray(Eigen::ArrayX3i::Ones(1, 3));
   ASSERT_FALSE(sample_agraph_1.IsFitnessSet());
+}
+
+TEST_F(AGraphTest, TestDistanceBetweenGraphs) {
+  ASSERT_EQ(sample_agraph_1.Distance(sample_agraph_1), 0);
+  sample_agraph_1.Distance(all_funcs_graph);
 }
 
 // class AGraphExceptionTest : public ::testing::Test {

--- a/tests/agraph_tests.cpp
+++ b/tests/agraph_tests.cpp
@@ -61,7 +61,7 @@ class AGraphTest : public ::testing::TestWithParam<std::string> {
 
   AGraph init_invalid_graph(AGraph& agraph) {
     AGraph return_val = AGraph();
-    return_val.setCommandArray(agraph.getCommandArray());
+    return_val.SetCommandArray(agraph.GetCommandArray());
     return return_val;
   }
 
@@ -79,7 +79,7 @@ class AGraphTest : public ::testing::TestWithParam<std::string> {
 
   AGraph init_all_funcs_graph() {
     AGraph test_graph = AGraph();
-    test_graph.setGeneticAge(10);
+    test_graph.SetGeneticAge(10);
     Eigen::ArrayX3i command_array(13, 3);
     command_array << 0, 0, 0,
                      1, 0, 0,
@@ -94,10 +94,10 @@ class AGraphTest : public ::testing::TestWithParam<std::string> {
                      10, 9, 0,
                      11, 10, 0,
                      12, 11, 0;
-    test_graph.setCommandArray(command_array);
+    test_graph.SetCommandArray(command_array);
     Eigen::VectorXd local_opt_params(2);
     local_opt_params << 1.0, 1.0;
-    test_graph.setLocalOptimizationParams(local_opt_params);
+    test_graph.SetLocalOptimizationParams(local_opt_params);
     return test_graph;
   }
 
@@ -129,25 +129,25 @@ class AGraphTest : public ::testing::TestWithParam<std::string> {
 };
 
 TEST_F(AGraphTest, copy) {
-  AGraph agraph_copy = sample_agraph_1.copy();
+  AGraph agraph_copy = sample_agraph_1.Copy();
 
-  Eigen::ArrayX3i command_array = sample_agraph_1.getCommandArray();
+  Eigen::ArrayX3i command_array = sample_agraph_1.GetCommandArray();
   command_array(1, 1) = 100;
-  sample_agraph_1.setCommandArray(command_array);
-  Eigen::VectorXd constants = sample_agraph_1.getLocalOptimizationParams();
+  sample_agraph_1.SetCommandArray(command_array);
+  Eigen::VectorXd constants = sample_agraph_1.GetLocalOptimizationParams();
   constants[0] = 100;
-  sample_agraph_1.setLocalOptimizationParams(constants);
+  sample_agraph_1.SetLocalOptimizationParams(constants);
 
-  ASSERT_EQ(agraph_copy.getGeneticAge(), 10);
-  ASSERT_EQ(agraph_copy.getCommandArray()(1,1), 0);
-  ASSERT_DOUBLE_EQ(agraph_copy.getLocalOptimizationParams()[0], 1.0);
+  ASSERT_EQ(agraph_copy.GetGeneticAge(), 10);
+  ASSERT_EQ(agraph_copy.GetCommandArray()(1,1), 0);
+  ASSERT_DOUBLE_EQ(agraph_copy.GetLocalOptimizationParams()[0], 1.0);
 }
 
 TEST_P(AGraphTest, latex_print) {
   std::string agraph_name = GetParam();
   std::string string_rep = map_to_graph_string.at(agraph_name).at("latex string");
   AGraph agraph = map_to_graph.at(agraph_name);
-  ASSERT_STREQ(string_rep.c_str(), agraph.getLatexString().c_str());
+  ASSERT_STREQ(string_rep.c_str(), agraph.GetLatexString().c_str());
 }
 
 TEST_P(AGraphTest, console_print) {
@@ -163,7 +163,7 @@ TEST_P(AGraphTest, complexity_print) {
   std::string agraph_name = GetParam();
   int complexity_val = std::stoi(map_to_graph_string.at(agraph_name).at("complexity"));
   AGraph agraph = map_to_graph.at(agraph_name);
-  ASSERT_EQ(complexity_val, agraph.getComplexity());
+  ASSERT_EQ(complexity_val, agraph.GetComplexity());
 }
 
 INSTANTIATE_TEST_CASE_P(,AGraphTest, ::testing::Values(
@@ -184,7 +184,7 @@ TEST_F(AGraphTest, stack_print) {
                    "(2) <= (0) + (1)\n"
                    "(3) <= sin (2)\n"
                    "(4) <= (3) + (1)\n";
-  ASSERT_STREQ(expected_str.str().c_str(), sample_agraph_1.getStackString().c_str());
+  ASSERT_STREQ(expected_str.str().c_str(), sample_agraph_1.GetStackString().c_str());
 }
 
 TEST_F(AGraphTest, invalid_stack_print) {
@@ -202,19 +202,19 @@ TEST_F(AGraphTest, invalid_stack_print) {
                    "(2) <= (0) + (1)\n"
                    "(3) <= sin (2)\n"
                    "(4) <= (3) + (1)\n";
-  ASSERT_STREQ(expected_str.str().c_str(), invalid_graph.getStackString().c_str());
+  ASSERT_STREQ(expected_str.str().c_str(), invalid_graph.GetStackString().c_str());
 }
 
 TEST_F(AGraphTest, evaluateAt) {
   ASSERT_TRUE(testutils::almost_equal(
     sample_agraph_1_values.f_of_x,
-    sample_agraph_1.evaluateEquationAt(sample_agraph_1_values.x)
+    sample_agraph_1.EvaluateEquationAt(sample_agraph_1_values.x)
   ));
 }
 
 TEST_F(AGraphTest, evaluatWithXDerivative) {
   Eigen::ArrayXXd x = sample_agraph_1_values.x;
-  EvalAndDerivative result = sample_agraph_1.evaluateEquationWithXGradientAt(x);
+  EvalAndDerivative result = sample_agraph_1.EvaluateEquationWithXGradientAt(x);
   Eigen::ArrayXXd f_of_x = result.first;
   Eigen::ArrayXXd df_dx = result.second;
   ASSERT_TRUE(testutils::almost_equal(sample_agraph_1_values.f_of_x, f_of_x));
@@ -223,7 +223,7 @@ TEST_F(AGraphTest, evaluatWithXDerivative) {
 
 TEST_F(AGraphTest, evaluatWithCDerivative) {
   Eigen::ArrayXXd x = sample_agraph_1_values.x;
-  EvalAndDerivative result = sample_agraph_1.evaluateEquationWithLocalOptGradientAt(x);
+  EvalAndDerivative result = sample_agraph_1.EvaluateEquationWithLocalOptGradientAt(x);
   Eigen::ArrayXXd f_of_x = result.first;
   Eigen::ArrayXXd df_dc = result.second;
   ASSERT_TRUE(testutils::almost_equal(sample_agraph_1_values.f_of_x, f_of_x));
@@ -231,41 +231,41 @@ TEST_F(AGraphTest, evaluatWithCDerivative) {
 }
 
 TEST_F(AGraphTest, get_number_of_optimization_params) {
-  ASSERT_TRUE(invalid_graph.needsLocalOptimization());
+  ASSERT_TRUE(invalid_graph.NeedsLocalOptimization());
 }
 
 TEST_F(AGraphTest, getNumberOfOptimizationParams) {
-  ASSERT_EQ(invalid_graph.getNumberLocalOptimizationParams(), 1);
+  ASSERT_EQ(invalid_graph.GetNumberLocalOptimizationParams(), 1);
 }
 
 TEST_F(AGraphTest, setOptimizationParams) {
   Eigen::VectorXd opt_params(1);
   opt_params << 1.0;
-  invalid_graph.setLocalOptimizationParams(opt_params);
-  ASSERT_FALSE(invalid_graph.needsLocalOptimization());
+  invalid_graph.SetLocalOptimizationParams(opt_params);
+  ASSERT_FALSE(invalid_graph.NeedsLocalOptimization());
   ASSERT_TRUE(testutils::almost_equal(
-    invalid_graph.evaluateEquationAt(sample_agraph_1_values.x),
-    sample_agraph_1.evaluateEquationAt(sample_agraph_1_values.x))
+    invalid_graph.EvaluateEquationAt(sample_agraph_1_values.x),
+    sample_agraph_1.EvaluateEquationAt(sample_agraph_1_values.x))
   );
 }
 
 TEST_F(AGraphTest, setting_fitness_updates_fit_set) {
   AGraph new_graph = AGraph();
-  ASSERT_FALSE(new_graph.isFitnessSet());
-  new_graph.setFitness(2.0);
-  ASSERT_TRUE(new_graph.isFitnessSet());
+  ASSERT_FALSE(new_graph.IsFitnessSet());
+  new_graph.SetFitness(2.0);
+  ASSERT_TRUE(new_graph.IsFitnessSet());
 }
 
 TEST_F(AGraphTest, notify_command_array_mod) {
-  ASSERT_TRUE(sample_agraph_1.isFitnessSet());
-  sample_agraph_1.notifyCommandArrayModificiation();
-  ASSERT_FALSE(sample_agraph_1.isFitnessSet());
+  ASSERT_TRUE(sample_agraph_1.IsFitnessSet());
+  sample_agraph_1.NotifyCommandArrayModificiation();
+  ASSERT_FALSE(sample_agraph_1.IsFitnessSet());
 }
 
 TEST_F(AGraphTest, setting_command_array_unsets_fitness) {
-  ASSERT_TRUE(sample_agraph_1.isFitnessSet());
-  sample_agraph_1.setCommandArray(Eigen::ArrayX3i::Ones(1, 3));
-  ASSERT_FALSE(sample_agraph_1.isFitnessSet());
+  ASSERT_TRUE(sample_agraph_1.IsFitnessSet());
+  sample_agraph_1.SetCommandArray(Eigen::ArrayX3i::Ones(1, 3));
+  ASSERT_FALSE(sample_agraph_1.IsFitnessSet());
 }
 
 // class AGraphExceptionTest : public ::testing::Test {

--- a/tests/test_fixtures.h
+++ b/tests/test_fixtures.h
@@ -63,12 +63,12 @@ inline bingo::AGraph init_sample_agraph_1() {
                         6, 2, 2,
                         2, 0, 1,
                         2, 3, 1;
-  test_graph.setCommandArray(test_command_array);
-  test_graph.setGeneticAge(10);
+  test_graph.SetCommandArray(test_command_array);
+  test_graph.SetGeneticAge(10);
   Eigen::VectorXd local_opt_params(1);
   local_opt_params << 1.0;
-  test_graph.setLocalOptimizationParams(local_opt_params);
-  test_graph.setFitness(1);
+  test_graph.SetLocalOptimizationParams(local_opt_params);
+  test_graph.SetFitness(1);
   return test_graph;
 }
 
@@ -81,12 +81,12 @@ inline bingo::AGraph init_sample_agraph_2() {
                         4, 0, 2,
                         2, 0, 1,
                         6, 3, 0;
-  test_graph.setCommandArray(test_command_array);
-  test_graph.setGeneticAge(20);
+  test_graph.SetCommandArray(test_command_array);
+  test_graph.SetGeneticAge(20);
   Eigen::VectorXd local_opt_params(2);
   local_opt_params << 1.0, 1.0;
-  test_graph.setLocalOptimizationParams(local_opt_params);
-  test_graph.setFitness(2);
+  test_graph.SetLocalOptimizationParams(local_opt_params);
+  test_graph.SetFitness(2);
   return test_graph;
 }
 } // namespace testutils


### PR DESCRIPTION
This PR contains changes to the AGraph class in c++ to reflect similar interface to the one in python. It contains changes to the casing for functions to reflect Google's style guide. This also contains an implementation of the AGraph that can be used in python via pybind11.