### PR TITLE
Equation interface for pybind

### DIFF
--- a/app/bingocpp_pymodule.cpp
+++ b/app/bingocpp_pymodule.cpp
@@ -51,6 +51,8 @@
 #include "BingoCpp/implicit_regression.h"
 #include "BingoCpp/utils.h"
 
+#include "python/py_equation.h"
+
 namespace py = pybind11;
 using namespace bingo;
 
@@ -70,6 +72,19 @@ PYBIND11_MODULE(bingocpp, m) {
         "get the commands that are utilized in a stack");
   m.def("simplify_stack", &backend::SimplifyStack,
         "simplify stack to only utilized commands");
+
+  py::class_<Equation, PyEquation /* <---trampoline */>(m, "Equation")
+    .def(py::init<>())
+    .def("evaluate_equation_at",
+         &Equation::EvaluateEquationAt)
+    .def("evaluate_equation_with_x_gradient_at",
+         &Equation::EvaluateEquationWithXGradientAt)
+    .def("evaluate_equation_with_local_opt_gradient_at",
+          &Equation::EvaluateEquationWithLocalOptGradientAt)
+    .def("get_latex_string", &Equation::GetLatexString)
+    .def("get_stack_string", &Equation::GetStackString)
+    .def("get_console_string", &Equation::GetConsoleString)
+    .def("get_complexity", &Equation::GetComplexity);
 
   py::class_<AGraph>(m, "AGraph")
     .def(py::init<bool & >(), py::arg("manual_constants") = false)
@@ -153,7 +168,7 @@ PYBIND11_MODULE(bingocpp, m) {
 
   m.def("calculate_partials", &CalculatePartials);
   m.def("savitzky_golay", &SavitzkyGolay);
-  m.def("GenFact", &GenFact);
-  m.def("GramPoly", &GramPoly);
-  m.def("GramWeight", &GramWeight);
+  m.def("gen_fact", &GenFact);
+  m.def("gram_poly", &GramPoly);
+  m.def("gram_weight", &GramWeight);
 }

--- a/include/python/py_equation.h
+++ b/include/python/py_equation.h
@@ -1,0 +1,86 @@
+#ifndef BINGOCPP_INCLUDE_BINGOCPP_PY_EQUATION_H_
+#define BINGOCPP_INCLUDE_BINGOCPP_PY_EQUATION_H_
+
+#include <string>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <pybind11/stl.h>
+
+#include "BingoCpp/equation.h"
+
+namespace bingo {
+
+class PyEquation : public Equation {
+ public:
+  Eigen::ArrayXXd 
+  EvaluateEquationAt(const Eigen::ArrayXXd &x) const override {
+    PYBIND11_OVERLOAD_PURE_NAME(
+      Eigen::ArrayXXd,
+      Equation,
+      "evaluate_equation_at",
+      EvaluateEquationAt,
+      x
+    );
+  }
+
+  EvalAndDerivative
+  EvaluateEquationWithXGradientAt(const Eigen::ArrayXXd &x) const override {
+    PYBIND11_OVERLOAD_PURE_NAME(
+      EvalAndDerivative,
+      Equation,
+      "evaluate_equation_with_x_gradient_at",
+      EvaluateEquationWithXGradientAt,
+      x
+    );
+  }
+
+  EvalAndDerivative
+  EvaluateEquationWithLocalOptGradientAt(const Eigen::ArrayXXd &x) const override {
+    PYBIND11_OVERLOAD_PURE_NAME(
+      EvalAndDerivative,
+      Equation,
+      "evaluate_equation_with_local_opt_gradient_at",
+      EvaluateEquationWithLocalOptGradientAt,
+      x
+    );
+  }
+
+  std::string GetLatexString() const override {
+    PYBIND11_OVERLOAD_PURE_NAME(
+      std::string,
+      Equation,
+      "get_latex_string",
+      GetLatexString,
+    );
+  }
+
+  std::string GetConsoleString() const override {
+    PYBIND11_OVERLOAD_PURE_NAME(
+      std::string,
+      Equation,
+      "get_console_string",
+      GetConsoleString,
+    );
+  }
+
+  std::string GetStackString() const override {
+    PYBIND11_OVERLOAD_PURE_NAME(
+      std::string,
+      Equation,
+      "get_Stack_string",
+      GetStackString,
+    );
+  }
+
+  int GetComplexity() const override {
+    PYBIND11_OVERLOAD_PURE_NAME(
+      int,
+      Equation,
+      "get_complexity",
+      GetComplexity,
+    );
+  }
+};
+} // namespace bingo
+#endif // BINGOCPP_INCLUDE_BINGOCPP_PY_EQUATION_H_


### PR DESCRIPTION
This contains an interface that may be extended in the python interpreter. This allows a python class that extends the interface to be passed to a pybind module that is expected the C++ equation interface.