### PR TITLE
Fixes to ExplicitRegression and metric functions

### DIFF
--- a/include/BingoCpp/gradient_mixin.h
+++ b/include/BingoCpp/gradient_mixin.h
@@ -24,18 +24,6 @@ class VectorGradientMixin : public GradientMixin {
   virtual std::tuple<Eigen::ArrayXd, Eigen::ArrayXXd> GetFitnessVectorAndJacobian(Equation &individual) const = 0;
 
  protected:
-  static double mean_absolute_error(const Eigen::ArrayXd &fitness_vector) {
-    return fitness_vector.abs().mean();
-  }
-
-  static double mean_squared_error(const Eigen::ArrayXd &fitness_vector) {
-    return fitness_vector.square().mean();
-  }
-
-  static double root_mean_squared_error(const Eigen::ArrayXd &fitness_vector) {
-    return sqrt(fitness_vector.square().mean());
-  }
-
   static Eigen::ArrayXd mean_absolute_error_derivative(
       const Eigen::ArrayXd &fitness_vector, const Eigen::ArrayXXd &fitness_partials) {
     return (fitness_partials.rowwise() * fitness_vector.transpose().sign()).rowwise().mean();

--- a/include/bingocpp/fitness_function.h
+++ b/include/bingocpp/fitness_function.h
@@ -29,18 +29,18 @@
 namespace metric_functions {
 
 const std::unordered_set<std::string> kMeanAbsoluteError = {
-    "mean_absolute_error",
-    "mae"
+  "mean_absolute_error",
+  "mae"
 };
 
 const std::unordered_set<std::string> kMeanSquaredError = {
-    "mean_squared_error",
-    "mse"
+  "mean_squared_error",
+  "mse"
 };
 
 const std::unordered_set<std::string> kRootMeanSquaredError = {
-    "root_mean_squared_error",
-    "rmse"
+  "root_mean_squared_error",
+  "rmse"
 };
 
 inline bool metric_found(const std::unordered_set<std::string> &set,

--- a/include/bingocpp/fitness_function.h
+++ b/include/bingocpp/fitness_function.h
@@ -26,22 +26,42 @@
 #include <bingocpp/equation.h>
 #include <bingocpp/training_data.h>
 
-namespace bingo {
+namespace metric_functions {
 
 const std::unordered_set<std::string> kMeanAbsoluteError = {
-  "mean_absolute_error",
-  "mae"
+    "mean_absolute_error",
+    "mae"
 };
 
 const std::unordered_set<std::string> kMeanSquaredError = {
-  "mean_squared_error",
-  "mse"
+    "mean_squared_error",
+    "mse"
 };
 
 const std::unordered_set<std::string> kRootMeanSquaredError = {
-  "root_mean_squared_error",
-  "rmse"
+    "root_mean_squared_error",
+    "rmse"
 };
+
+inline bool metric_found(const std::unordered_set<std::string> &set,
+                         std::string metric) {
+  return set.find(metric) != set.end();
+}
+
+inline double mean_absolute_error(const Eigen::ArrayXd &fitness_vector) {
+  return fitness_vector.abs().mean();
+}
+
+inline double root_mean_squared_error(const Eigen::ArrayXd &fitness_vector) {
+  return sqrt(fitness_vector.square().mean());
+}
+
+inline double mean_squared_error(const Eigen::ArrayXd &fitness_vector) {
+  return fitness_vector.square().mean();
+}
+} // namespace metric_functions
+
+namespace bingo {
 
 class FitnessFunction {
  public:
@@ -65,11 +85,6 @@ class FitnessFunction {
   TrainingData* training_data_;
 };
 
-inline bool metric_found(const std::unordered_set<std::string> &set,
-                         std::string metric) {
-  return set.find(metric) != set.end();
-}
-
 class VectorBasedFunction : public FitnessFunction {
  public:
   typedef double (VectorBasedFunction::* MetricFunctionPointer)(const Eigen::ArrayXXd&);
@@ -92,25 +107,13 @@ class VectorBasedFunction : public FitnessFunction {
  protected:
   std::string metric_;
 
-  static double mean_absolute_error(const Eigen::ArrayXd &fitness_vector) {
-    return fitness_vector.abs().mean();
-  }
-
-  static double root_mean_squared_error(const Eigen::ArrayXd &fitness_vector) {
-    return sqrt(fitness_vector.square().mean());
-  }
-
-  static double mean_squared_error(const Eigen::ArrayXd &fitness_vector) {
-    return fitness_vector.square().mean();
-  }
-
   std::function<double(Eigen::ArrayXd)> GetMetric(std::string metric) {
-    if (metric_found(kMeanAbsoluteError, metric)) {
-      return VectorBasedFunction::mean_absolute_error;
-    } else if (metric_found(kMeanSquaredError, metric)) {
-      return VectorBasedFunction::mean_squared_error;
-    } else if (metric_found(kRootMeanSquaredError, metric)) {
-      return VectorBasedFunction::root_mean_squared_error;
+    if (metric_functions::metric_found(metric_functions::kMeanAbsoluteError, metric)) {
+      return metric_functions::mean_absolute_error;
+    } else if (metric_functions::metric_found(metric_functions::kMeanSquaredError, metric)) {
+      return metric_functions::mean_squared_error;
+    } else if (metric_functions::metric_found(metric_functions::kRootMeanSquaredError, metric)) {
+      return metric_functions::root_mean_squared_error;
     } else {
       throw std::invalid_argument("Invalid metric for Fitness Function");
     }

--- a/src/explicit_regression.cpp
+++ b/src/explicit_regression.cpp
@@ -35,13 +35,17 @@ Eigen::ArrayXd ExplicitRegression::EvaluateFitnessVector(
 
 std::tuple<Eigen::ArrayXd, Eigen::ArrayXXd> ExplicitRegression::GetFitnessVectorAndJacobian(
     Equation &individual) const {
+  ++ eval_count_;
   Eigen::ArrayXXd f_of_x, df_dc;
   const Eigen::ArrayXXd x = ((ExplicitTrainingData*)training_data_)->x;
   std::tie(f_of_x, df_dc) = individual.EvaluateEquationWithLocalOptGradientAt(x);
+
+  Eigen::ArrayXXd error = f_of_x - ((ExplicitTrainingData*)training_data_)->y;
   if (relative_) {
+    error /= ((ExplicitTrainingData*)training_data_)->y;
     df_dc.colwise() /= ((ExplicitTrainingData*)training_data_)->y(Eigen::all, 0);
   }
-  return std::tuple<Eigen::ArrayXd, Eigen::ArrayXXd>{this->EvaluateFitnessVector(individual), df_dc};
+  return std::tuple<Eigen::ArrayXd, Eigen::ArrayXXd>{error, df_dc};
 }
 
 ExplicitRegressionState ExplicitRegression::DumpState() {

--- a/src/gradient_mixin.cpp
+++ b/src/gradient_mixin.cpp
@@ -6,14 +6,14 @@
 namespace bingo {
 
 VectorGradientMixin::VectorGradientMixin(TrainingData *training_data, std::string metric) {
-  if (metric_found(kMeanAbsoluteError, metric)) {
-    metric_function_ = VectorGradientMixin::mean_absolute_error;
+  if (metric_functions::metric_found(metric_functions::kMeanAbsoluteError, metric)) {
+    metric_function_ = metric_functions::mean_absolute_error;
     metric_derivative_ = VectorGradientMixin::mean_absolute_error_derivative;
-  } else if (metric_found(kMeanSquaredError, metric)) {
-    metric_function_ = VectorGradientMixin::mean_squared_error;
+  } else if (metric_functions::metric_found(metric_functions::kMeanSquaredError, metric)) {
+    metric_function_ = metric_functions::mean_squared_error;
     metric_derivative_ = VectorGradientMixin::mean_squared_error_derivative;
-  } else if (metric_found(kRootMeanSquaredError, metric)) {
-    metric_function_ = VectorGradientMixin::root_mean_squared_error;
+  } else if (metric_functions::metric_found(metric_functions::kRootMeanSquaredError, metric)) {
+    metric_function_ = metric_functions::root_mean_squared_error;
     metric_derivative_ = VectorGradientMixin::root_mean_squared_error_derivative;
   } else {
     throw std::invalid_argument("Invalid metric for VectorGradientMixin");

--- a/tests/explicit_regression_tests.cpp
+++ b/tests/explicit_regression_tests.cpp
@@ -37,25 +37,32 @@ class TestExplicitRegression : public testing::Test {
 
 TEST_F(TestExplicitRegression, EvaluateIndividualFitness) {
   ExplicitRegression regressor(training_data_);
+  ASSERT_EQ(regressor.GetEvalCount(), 0);
   double fitness = regressor.EvaluateIndividualFitness(sum_equation_);
   ASSERT_NEAR(fitness, 2.5, 1e-10);
+  ASSERT_EQ(regressor.GetEvalCount(), 1);
 }
 
 TEST_F(TestExplicitRegression, EvaluateIndividualFitnessRelative) {
   ExplicitRegression regressor(training_data_, "mae", true);
+  ASSERT_EQ(regressor.GetEvalCount(), 0);
   double fitness = regressor.EvaluateIndividualFitness(sum_equation_);
   ASSERT_NEAR(fitness, 1.0, 1e-10);
+  ASSERT_EQ(regressor.GetEvalCount(), 1);
 }
 
 TEST_F(TestExplicitRegression, EvaluateIndividualFitnessWithNaN) {
   training_data_->x(0, 0) = std::numeric_limits<double>::quiet_NaN();
   ExplicitRegression regressor(training_data_);
+  ASSERT_EQ(regressor.GetEvalCount(), 0);
   double fitness = regressor.EvaluateIndividualFitness(sum_equation_);
   ASSERT_TRUE(std::isnan(fitness));
+  ASSERT_EQ(regressor.GetEvalCount(), 1);
 }
 
 TEST_F(TestExplicitRegression, GetIndividualFitnessAndGradient) {
   ExplicitRegression regressor(training_data_);
+  ASSERT_EQ(regressor.GetEvalCount(), 0);
   Eigen::ArrayXd expected_gradient = Eigen::ArrayXd::Constant(5, 1, 1.0);
 
   double fitness;
@@ -64,10 +71,12 @@ TEST_F(TestExplicitRegression, GetIndividualFitnessAndGradient) {
 
   ASSERT_NEAR(fitness, 2.5, 1e-10);
   ASSERT_TRUE(expected_gradient.isApprox(gradient));
+  ASSERT_EQ(regressor.GetEvalCount(), 1);
 }
 
 TEST_F(TestExplicitRegression, GetIndividualFitnessAndGradientRelative) {
   ExplicitRegression regressor(training_data_, "mae", true);
+  ASSERT_EQ(regressor.GetEvalCount(), 0);
   Eigen::ArrayXd expected_gradient = Eigen::ArrayXd::Constant(5, 1, 1.0/2.5);
 
   double fitness;
@@ -76,10 +85,12 @@ TEST_F(TestExplicitRegression, GetIndividualFitnessAndGradientRelative) {
 
   ASSERT_NEAR(fitness, 1.0, 1e-10);
   ASSERT_TRUE(expected_gradient.isApprox(gradient));
+  ASSERT_EQ(regressor.GetEvalCount(), 1);
 }
 
 TEST_F(TestExplicitRegression, GetFitnessVectorAndJacobian) {
   ExplicitRegression regressor(training_data_);
+  ASSERT_EQ(regressor.GetEvalCount(), 0);
   Eigen::ArrayXd expected_fitness_vector = Eigen::ArrayXd::Constant(10, 1, 2.5);
   Eigen::ArrayXXd expected_jacobian = training_data_->x;
 
@@ -89,10 +100,12 @@ TEST_F(TestExplicitRegression, GetFitnessVectorAndJacobian) {
 
   ASSERT_TRUE(expected_fitness_vector.isApprox(fitness_vector));
   ASSERT_TRUE(expected_jacobian.isApprox(jacobian));
+  ASSERT_EQ(regressor.GetEvalCount(), 1);
 }
 
 TEST_F(TestExplicitRegression, GetFitnessVectorAndJacobianRelative) {
   ExplicitRegression regressor(training_data_, "mae", true);
+  ASSERT_EQ(regressor.GetEvalCount(), 0);
   Eigen::ArrayXd expected_fitness_vector = Eigen::ArrayXd::Constant(10, 1, 1.0);
   Eigen::ArrayXXd expected_jacobian = Eigen::ArrayXXd::Constant(10, 5, 1.0/2.5);
 
@@ -102,6 +115,7 @@ TEST_F(TestExplicitRegression, GetFitnessVectorAndJacobianRelative) {
 
   ASSERT_TRUE(expected_fitness_vector.isApprox(fitness_vector));
   ASSERT_TRUE(expected_jacobian.isApprox(jacobian));
+  ASSERT_EQ(regressor.GetEvalCount(), 1);
 }
 
 TEST_F(TestExplicitRegression, GetSubsetOfTrainingData) {


### PR DESCRIPTION
Removed unnecessary EvaluateFitnessVector() call in ExplicitRegression::GetFitnessVectorAndJacobian() and added eval count checks in ExplicitRegression's test cases. Also moved FitnessFunction's metric functions into their own namespace to avoid code duplication when using metric functions in GradientMixin.